### PR TITLE
Display default blocks during createPB, fix leaderboard number issue

### DIFF
--- a/src/me/A5H73Y/Parkour/Conversation/LeaderboardConversation.java
+++ b/src/me/A5H73Y/Parkour/Conversation/LeaderboardConversation.java
@@ -36,7 +36,7 @@ public class LeaderboardConversation extends StringPrompt {
 	private class ChooseType extends FixedSetPrompt {
 
 		ChooseType(){
-			super("Personal", "Global", "Cancel");
+			super("personal", "global");
 		}
 
 		@Override
@@ -46,8 +46,10 @@ public class LeaderboardConversation extends StringPrompt {
 
 		@Override
 		protected Prompt acceptValidatedInput(ConversationContext context, String choice) {
+			/* not needed as 'cancel' will do the job
 			if (choice.equals("Cancel"))
 				return Prompt.END_OF_CONVERSATION;
+			*/
 
 			context.setSessionData("type", choice);
 
@@ -64,7 +66,7 @@ public class LeaderboardConversation extends StringPrompt {
 
 		@Override
 		protected boolean isNumberValid(ConversationContext context, Number input) {
-			return input.intValue() > 0 && input.intValue() < 20;
+			return input.intValue() > 0 && input.intValue() <= 20;
 		}
 
 		@Override
@@ -90,9 +92,9 @@ public class LeaderboardConversation extends StringPrompt {
 			Bukkit.getScheduler().runTaskLaterAsynchronously(Parkour.getPlugin(), new Runnable() {
 				@Override
 				public void run() {
-					if (leaderboardType.equals("Personal")) {
+					if (leaderboardType.equals("personal")) {
 						Utils.displayLeaderboard(DatabaseMethods.getTopPlayerCourseResults(player.getName(), courseName, amount), player);
-					} else if (leaderboardType.equals("Global")) {
+					} else if (leaderboardType.equals("global")) {
 						Utils.displayLeaderboard(DatabaseMethods.getTopCourseResults(courseName, amount), player);
 					}
 				}

--- a/src/me/A5H73Y/Parkour/Conversation/ParkourBlockConversation.java
+++ b/src/me/A5H73Y/Parkour/Conversation/ParkourBlockConversation.java
@@ -35,7 +35,11 @@ public class ParkourBlockConversation extends StringPrompt {
 		@Override
 		public String getPromptText(ConversationContext context) {
 			int stage = getBlockStage(context);
-			return ChatColor.LIGHT_PURPLE + " What material do you want for the " + ChatColor.WHITE + blockTypes[stage] + ChatColor.LIGHT_PURPLE + " block?";
+			String blockType = blockTypes[stage];
+			Material material = Material.getMaterial(
+					Parkour.getParkourConfig().getConfig().getString("DefaultBlocks." + blockType + ".Material").toUpperCase());
+			
+			return ChatColor.LIGHT_PURPLE + " What material do you want for the " + ChatColor.WHITE + blockTypes[stage] + ChatColor.LIGHT_PURPLE + " block?\n [default = " + ChatColor.GOLD + material + ChatColor.LIGHT_PURPLE + "]";
 		}
 
 		@Override

--- a/src/me/A5H73Y/Parkour/Player/PlayerMethods.java
+++ b/src/me/A5H73Y/Parkour/Player/PlayerMethods.java
@@ -203,19 +203,23 @@ public class PlayerMethods {
 			for (Player players : Bukkit.getServer().getOnlinePlayers()) {
 				players.sendMessage(finishBroadcast);
 			}
-			return;
+			break;
 		case 2:
 			for (Player players : Bukkit.getServer().getOnlinePlayers()) {
 				if (PlayerMethods.isPlaying(players.getPlayerListName())) {
 					players.sendMessage(finishBroadcast);
 				}
 			}
-			return;
+			break;
 		case 1:
 		default:
 			player.sendMessage(finishBroadcast);
 		}
-
+		if (Parkour.getParkourConfig().getConfig().getBoolean("OnFinish.TeleportToLobby")) {
+			player.sendMessage("Teleporting to lobby....");
+			/** Allow player to bask in the glory of completing course before teleport to lobby **/
+			Utils.sleep(3500);
+		}
 	}
 
 	/**

--- a/src/me/A5H73Y/Parkour/Utilities/Utils.java
+++ b/src/me/A5H73Y/Parkour/Utilities/Utils.java
@@ -627,4 +627,9 @@ public final class Utils {
 	public static List<String> getParkourBlockList(){
 		return new ArrayList<String>(Parkour.getParkourConfig().getConfig().getConfigurationSection("ParkourBlocks").getKeys(false));
 	}
+	public static void sleep (int time) {
+		try {
+			Thread.sleep(time);
+		} catch (Exception e) {}
+	}
 }


### PR DESCRIPTION
1) fixes issue of '20' not being a valid number for leaderboard entries to display
2) added small delay when player finishes course before teleporting back to lobby - on completing a long course, its a little unsatisfactory to be pinged straight back to the lobby.
3) when creating a PB set, display the current default block for  each type, to help with choosing a new one or keeping the default block
4) leaderboard types (personal/global) should be lower case to be consistent with the course prize conversation types. The cancel option doesn't need to be included here, as its already an option in getEntryPrompt in ParkourConversation.java.