### PR TITLE
fixes #9 - issue with command whitelist

### DIFF
--- a/src/me/A5H73Y/Parkour/ParkourListener.java
+++ b/src/me/A5H73Y/Parkour/ParkourListener.java
@@ -376,7 +376,7 @@ public class ParkourListener implements Listener {
 
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onCommandPreprocess(PlayerCommandPreprocessEvent event) {
-		boolean commandIsPa = event.getMessage().startsWith("/pa");
+		boolean commandIsPa = (event.getMessage().startsWith("/pa ") || event.getMessage().startsWith("/parkour") || event.getMessage().equals("/pa"));
 		Player player = event.getPlayer();
 
 		if (commandIsPa && Static.containsQuestion(player.getName())) {
@@ -392,7 +392,7 @@ public class ParkourListener implements Listener {
 				return;
 
 			boolean allowed = false;
-			for (String word : Parkour.getParkourConfig().getConfig().getStringList("Other.Commands.Whitelist")) {
+			for (String word : Parkour.getParkourConfig().getConfig().getStringList("OnCourse.EnforceParkourCommands.Whitelist")) {
 				if (event.getMessage().startsWith("/" + word)) {
 					allowed = true;
 					break;


### PR DESCRIPTION
Changed line 395 to reference the correct entry in the config.yml. Seems to work ok with the testing I've done.

The "commandIsPa" boolean would have returned true for commands starting with /pa, e.g. /pay, /pardon, /particle,......(can't think of any more!).  Maybe there's a more elegant way, but needs to allow "/pa" which is valid, as well as "/pa subcommand".
