### PR TITLE
add course name to leaderboard display

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Conversation/LeaderboardConversation.java
+++ b/src/main/java/me/A5H73Y/Parkour/Conversation/LeaderboardConversation.java
@@ -96,9 +96,9 @@ public class LeaderboardConversation extends StringPrompt {
 				@Override
 				public void run() {
 					if (leaderboardType.equals("personal")) {
-						Utils.displayLeaderboard(player, DatabaseMethods.getTopPlayerCourseResults(player.getName(), courseName, amount));
+						Utils.displayLeaderboard(player, DatabaseMethods.getTopPlayerCourseResults(player.getName(), courseName, amount), courseName);
 					} else if (leaderboardType.equals("global")) {
-						Utils.displayLeaderboard(player, DatabaseMethods.getTopCourseResults(courseName, amount));
+						Utils.displayLeaderboard(player, DatabaseMethods.getTopCourseResults(courseName, amount), courseName);
 					}
 				}
 			}, 3);

--- a/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
@@ -939,7 +939,7 @@ public class CourseMethods {
 
 	/**
 	 * Retrieve and display Leaderboard for a course
-	 * Can be specifed direction using appropriate commands,
+	 * Can be specified direction using appropriate commands,
 	 * or the Leaderboard conversation can be started, to specify what you want to view based on the options
 	 * 
 	 * @param args
@@ -978,9 +978,9 @@ public class CourseMethods {
 		}
 
 		if (personal) {
-			Utils.displayLeaderboard(player, DatabaseMethods.getTopPlayerCourseResults(player.getName(), args[1], limit));
+			Utils.displayLeaderboard(player, DatabaseMethods.getTopPlayerCourseResults(player.getName(), args[1], limit), args[1]);
 		} else {
-			Utils.displayLeaderboard(player, DatabaseMethods.getTopCourseResults(args[1], limit));
+			Utils.displayLeaderboard(player, DatabaseMethods.getTopCourseResults(args[1], limit), args[1]);
 		}
 	}
 

--- a/src/main/java/me/A5H73Y/Parkour/ParkourSignListener.java
+++ b/src/main/java/me/A5H73Y/Parkour/ParkourSignListener.java
@@ -197,7 +197,7 @@ public class ParkourSignListener implements Listener {
 
 			} else {
 				Utils.displayLeaderboard(event.getPlayer(), 
-						DatabaseMethods.getTopCourseResults(lines[2]));
+						DatabaseMethods.getTopCourseResults(lines[2]), lines[2]);
 			}
 
 		} else {

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Utils.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Utils.java
@@ -680,14 +680,15 @@ public final class Utils {
 	 * Present the course times to the player.
 	 * @param times
 	 * @param player
+	 * @param course
 	 */
-	public static void displayLeaderboard(Player player, List<TimeObject> times) {
+	public static void displayLeaderboard(Player player, List<TimeObject> times, String courseName) {
 		if (times.size() == 0) {
 			player.sendMessage(Static.getParkourString() + "No results were found!");
 			return;
 		}
-
-		player.sendMessage(Utils.getStandardHeading(times.size() + " results"));
+		
+		player.sendMessage(Utils.getStandardHeading(courseName + " : Top " + times.size() + " results"));
 		for (int i = 0; i < times.size(); i++) {
 			player.sendMessage(Utils.colour((i + 1) + ") &b" + times.get(i).getPlayer() + "&f in &3" + Utils.calculateTime(times.get(i).getTime()) + "&f, dying &7" + times.get(i).getDeaths() + " &ftimes"));
 		}


### PR DESCRIPTION
Hi Ash,
just an idea for a small tweak to the leaderboard output. So for example instead of 
-- 5 results --
-- 10 results --
etc.
 you get
-- pk1: Top 5 results --
-- pk2: Top 10 resuts --

It makes the output clearer if you click on a few leaderboard signs then look back at the output.
Regards,
Steve