### PR TITLE
fixes right-click interaction

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/ParkourListener.java
+++ b/src/main/java/me/A5H73Y/Parkour/ParkourListener.java
@@ -36,6 +36,7 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerToggleFlightEvent;
+import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
@@ -306,16 +307,23 @@ public class ParkourListener implements Listener {
 
 		Player player = event.getPlayer();
 
-		if (!player.isSneaking() && Parkour.getParkourConfig().getConfig().getBoolean("OnCourse.SneakToInteractItems")) {
-			event.setCancelled(true);
-			return;
-		}
-
 		if (!event.getAction().equals(Action.RIGHT_CLICK_BLOCK) && !event.getAction().equals(Action.RIGHT_CLICK_AIR))
 			return;
 
 		if (PlayerMethods.isPlayerInTestmode(player.getName()))
 			return;
+		
+		if (Utils.getMaterialInPlayersHand(player) == Material.AIR) {
+			if (event.getClickedBlock().getState() instanceof InventoryHolder || event.getClickedBlock().getType() == Material.WORKBENCH){
+				event.setCancelled(true);
+			}
+			return;
+		}
+		
+		if (!player.isSneaking() && Parkour.getParkourConfig().getConfig().getBoolean("OnCourse.SneakToInteractItems")) {
+			event.setCancelled(true);
+			return;
+		}
 		
 		event.setCancelled(true);
         

--- a/src/main/java/me/A5H73Y/Parkour/ParkourListener.java
+++ b/src/main/java/me/A5H73Y/Parkour/ParkourListener.java
@@ -313,20 +313,20 @@ public class ParkourListener implements Listener {
 		if (PlayerMethods.isPlayerInTestmode(player.getName()))
 			return;
 		
-		if (Utils.getMaterialInPlayersHand(player) == Material.AIR) {
-			if (event.getClickedBlock().getState() instanceof InventoryHolder || event.getClickedBlock().getType() == Material.WORKBENCH){
+		Block block = event.getClickedBlock();
+		if (block != null) {
+			if (block.getState() instanceof InventoryHolder || block.getType() == Material.WORKBENCH)
 				event.setCancelled(true);
-			}
-			return;
 		}
 		
-		if (!player.isSneaking() && Parkour.getParkourConfig().getConfig().getBoolean("OnCourse.SneakToInteractItems")) {
-			event.setCancelled(true);
+		if (!player.isSneaking() && Parkour.getParkourConfig().getConfig().getBoolean("OnCourse.SneakToInteractItems"))
 			return;
-		}
+		
+		if (Utils.getMaterialInPlayersHand(player) == Material.AIR) 
+			return;
 		
 		event.setCancelled(true);
-        
+		
 		if (Utils.getMaterialInPlayersHand(player) == Parkour.getSettings().getLastCheckpoint()) {
 			if (Utils.delayPlayerEvent(player, 1))
 				PlayerMethods.playerDie(player);

--- a/src/main/java/me/A5H73Y/Parkour/ParkourListener.java
+++ b/src/main/java/me/A5H73Y/Parkour/ParkourListener.java
@@ -306,8 +306,10 @@ public class ParkourListener implements Listener {
 
 		Player player = event.getPlayer();
 
-		if (!player.isSneaking() && Parkour.getParkourConfig().getConfig().getBoolean("OnCourse.SneakToInteractItems"))
+		if (!player.isSneaking() && Parkour.getParkourConfig().getConfig().getBoolean("OnCourse.SneakToInteractItems")) {
+			event.setCancelled(true);
 			return;
+		}
 
 		if (!event.getAction().equals(Action.RIGHT_CLICK_BLOCK) && !event.getAction().equals(Action.RIGHT_CLICK_AIR))
 			return;
@@ -315,7 +317,7 @@ public class ParkourListener implements Listener {
 		if (PlayerMethods.isPlayerInTestmode(player.getName()))
 			return;
 		
-        event.setCancelled(true);
+		event.setCancelled(true);
         
 		if (Utils.getMaterialInPlayersHand(player) == Parkour.getSettings().getLastCheckpoint()) {
 			if (Utils.delayPlayerEvent(player, 1))


### PR DESCRIPTION
Hi Ash,
I was looking at the issue regarding right click interaction with chests, crafting tables etc. that mibby raised. The change cancels the right click event when OnCourse.SneakToInteract is false, i.e. a normal right-click gets cancelled during the game. Clicking a 'leave' sign still works.

It does fix the problem, but I'd prefer you to check the logic of doing that.
Thanks,
Steve