### PR TITLE
some minor updates for your consideration

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
@@ -220,6 +220,7 @@ public class CourseMethods {
 		String creator = config.getString(courseName + ".Creator");
 		boolean finished = config.getBoolean(courseName + ".Finished");
 		String parkourBlocks = config.getString(courseName + ".ParkourBlocks");
+		String mode = config.getString(courseName + ".Mode");
 
 		double completePercent = Math.round(((completed * 1.0 / views) * 100));
 
@@ -254,6 +255,9 @@ public class CourseMethods {
 		
 		if (parkourBlocks != null && parkourBlocks.length() > 0)
 			player.sendMessage("ParkourBlocks: " + aqua + parkourBlocks);
+		
+		if (mode != null && !"none".equalsIgnoreCase(mode))
+			player.sendMessage("Mode: " + aqua + mode);
 
 		double likePercent = Math.round(DatabaseMethods.getVotePercent(courseName));
 
@@ -629,7 +633,8 @@ public class CourseMethods {
 	public static void setFinish(String[] args, Player player) {
 		String courseName = PlayerMethods.getSelected(player.getName());
 
-		if (Parkour.getParkourConfig().getCourseData().contains(courseName + ".Finished")) {
+		//if (Parkour.getParkourConfig().getCourseData().contains(courseName + ".Finished")) {
+		if (isReady(courseName)){
 			player.sendMessage(Static.getParkourString() + ChatColor.AQUA + courseName + ChatColor.WHITE + " has already been set to finished!");
 			return;
 		}
@@ -726,6 +731,7 @@ public class CourseMethods {
 		config.set(courseName + ".LinkedLobby", null);
 		config.set(courseName + ".LinkedCourse", null);
 		config.set(courseName + ".ParkourBlocks", null);
+		config.set(courseName + ".Mode", null);
 		Parkour.getParkourConfig().saveCourses();
 		DatabaseMethods.deleteCourseTimes(courseName);
 	}

--- a/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
@@ -20,7 +20,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -633,7 +632,6 @@ public class CourseMethods {
 	public static void setFinish(String[] args, Player player) {
 		String courseName = PlayerMethods.getSelected(player.getName());
 
-		//if (Parkour.getParkourConfig().getCourseData().contains(courseName + ".Finished")) {
 		if (isReady(courseName)){
 			player.sendMessage(Static.getParkourString() + ChatColor.AQUA + courseName + ChatColor.WHITE + " has already been set to finished!");
 			return;

--- a/src/main/java/me/A5H73Y/Parkour/Other/Help.java
+++ b/src/main/java/me/A5H73Y/Parkour/Other/Help.java
@@ -61,8 +61,8 @@ public final class Help {
 					" Your Parkour permissions will be displayed based on the group permissions you have. For example, if you have 'Parkour.Admin.*', then you are a part of the Admin group, same for 'Parkour.Basic.*' etc. However, if you have been given only a selection of permissions from that group, it will not display, for example 'Parkour.Admin.Testmode' does not make you an admin. 'Parkour.*' will give you all Parkour permissions.");
 
 		} else if (args[1].equalsIgnoreCase("like") || args[1].equalsIgnoreCase("dislike")){	
-			displayHelpMessage(sender, "Vote opinion of course", "/pa [like / dislike]", null,
-					" Once you complete a course, you will have the ability to submit your vote on whether or not you liked the course. You only have one vote for each course. The sole purpose of this is for statistics, i.e. 70% of people liked this course.");
+			displayHelpMessage(sender, "Vote opinion of course", "/pa [like / dislike] [course]", null,
+					" Once you complete a course, you will have the ability to submit your vote on whether or not you liked the course. If you do not specify a course then the last course completed is selected. You only have one vote for each course. The sole purpose of this is for statistics, i.e. 70% of people liked this course.");
 
 		} else if (args[1].equalsIgnoreCase("list")){	
 			displayHelpMessage(sender, "Display Courses / Parkour players", "/pa list [courses / players]", null, 


### PR DESCRIPTION
This PR covers the following :

1. if a course has a Parkour mode set, then "/pa stats course" should display the mode.

2. When a course is reset, <coursename>.Finished is set to false in the config. Running "/pa finish" on the selected course its not possible to reset it to true (as it reports course is "already finished").

3. "/pa reset course" should reset the mode of a course - currently it leaves the mode in place.

4. update the syntax output by "/pa help like" to include the optional course name

5. remove unused import in courseMethods since creation of lobbyMethods.
