### PR TITLE
fixes #42 and #51

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/ParkourListener.java
+++ b/src/main/java/me/A5H73Y/Parkour/ParkourListener.java
@@ -334,16 +334,22 @@ public class ParkourListener implements Listener {
 			return;
         
 		if (Utils.getMaterialInPlayersHand(player) == Parkour.getSettings().getLastCheckpoint()) {
-			if (Utils.delayPlayerEvent(player, 1))
+			if (Utils.delayPlayerEvent(player, 1)) {
+				event.setCancelled(true);
 				PlayerMethods.playerDie(player);
+			}
 
 		} else if (Utils.getMaterialInPlayersHand(player) == Parkour.getSettings().getHideall()) {
-			if (Utils.delayPlayerEvent(player, 1))
+			if (Utils.delayPlayerEvent(player, 1)) {
+				event.setCancelled(true);
 				Utils.toggleVisibility(player);
+			}
 
 		} else if (Utils.getMaterialInPlayersHand(player) == Parkour.getSettings().getLeave()) {
-			if (Utils.delayPlayerEvent(player, 1))
+			if (Utils.delayPlayerEvent(player, 1)) {
+				event.setCancelled(true);
 				PlayerMethods.playerLeave(player);
+			}
 		}
 	}
 


### PR DESCRIPTION
This change prevents any of the 3 parkour items being placed or planted in-game resulting in inventory losses as mentioned in #42 and #51.
The interaction event is cancelled only at the point where the item in hand is being used as a parkour tool to exit, return to checkpoint or toggle invisibility, and so shouldn't have any other outcome (e.g. item should not be placed or planted).