### PR TITLE
fixes #70 getHandlerList should be a static method

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Events/ParkourEvent.java
+++ b/src/main/java/me/A5H73Y/Parkour/Events/ParkourEvent.java
@@ -26,7 +26,7 @@ public class ParkourEvent extends Event implements Cancellable {
         return handlers;
     }
 
-    public HandlerList getHandlerList() {
+    public static HandlerList getHandlerList() {
         return handlers;
     }
 


### PR DESCRIPTION
As per comment here:
[https://hub.spigotmc.org/jira/browse/SPIGOT-308](url)

>Event classes require a static getHandlerList() method in order to work, this is a "feature" of the event system bukkit uses.
