### PR TITLE
kit permissions

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/ParkourCommands.java
+++ b/src/main/java/me/A5H73Y/Parkour/ParkourCommands.java
@@ -308,16 +308,16 @@ class ParkourCommands implements CommandExecutor {
                         new ParkourConversation(player, ConversationType.EDITPARKOURKIT).begin();
 
 					} else if (args[0].equalsIgnoreCase("linkkit")) {
-						if (!Utils.hasPermission(player, "Parkour.Admin"))
-							return false;
-
 						if (!Utils.validateArgs(player, args, 3))
 							return false;
 
+						if (!Utils.hasPermissionOrCourseOwnership(player, "Parkour.Admin", "Course", args[1]))
+							return false;
+						
 						CourseMethods.linkParkourKit(args, player);
 						
 					} else if (args[0].equalsIgnoreCase("listkit")) {
-						if (!Utils.hasPermission(player, "Parkour.Admin"))
+						if (!Utils.hasPermission(player, "Parkour.Basic", "Kit"))
 							return false;
 
 						Utils.listParkourKit(args, player);


### PR DESCRIPTION
Hi Ash,

Currently a player with 'parkour.basic.kit' can get a kit from "/pa kit \<kitname\>" but is unable to see the available kits, as "/pa listkit" needs ''parkour.admin". So it kind of makes sense to allow 'parkour.basic.kit' to list the kits so the player can choose one.

Also, having chosen a kit and created a course it makes sense to be able to link the kit to the course. So we could allow the course creator permission to run "/pa linkkit \<course\> \<kit\>".
As the creator of a course can already run "/pa link" to link the selected course to a lobby or another course, so linking a kit should be ok too.

Cheers,

Steve
