### PR TITLE
Added an option to prevent players from attacking other entities

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Other/Configurations.java
+++ b/src/main/java/me/A5H73Y/Parkour/Other/Configurations.java
@@ -435,6 +435,7 @@ public class Configurations {
 		config.addDefault("OnCourse.SneakToInteractItems", true);
 		config.addDefault("OnCourse.AdminPlaceBreakBlocks", true);
 		config.addDefault("OnCourse.PreventOpeningOtherInventories", false);
+		config.addDefault("OnCourse.PreventAttackingEntities", false);
 
 		config.addDefault("OnFinish.EnforceCompletion", true);
 		config.addDefault("OnFinish.TeleportAway", true);

--- a/src/main/java/me/A5H73Y/Parkour/ParkourListener.java
+++ b/src/main/java/me/A5H73Y/Parkour/ParkourListener.java
@@ -29,6 +29,7 @@ import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
@@ -216,9 +217,20 @@ public class ParkourListener implements Listener {
 
     @EventHandler
     public void onEntityDamageEntity(EntityDamageByEntityEvent event) {
-        if (event.getEntity() instanceof Player)
+        if (event.getEntity() instanceof Player) {
             if (PlayerMethods.isPlaying(((Player)event.getEntity()).getName()))
                 event.setCancelled(true);
+        } else if (event.getDamager() instanceof Player) {
+            if (PlayerMethods.isPlaying(((Player)event.getDamager()).getName()))
+                if (Parkour.getSettings().isPreventAttackingEntities())
+                    event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerBreakingHangingItem(HangingBreakByEntityEvent event) {
+        if (event.getRemover() instanceof Player && PlayerMethods.isPlaying(((Player)event.getRemover()).getName()) && Parkour.getSettings().isPreventAttackingEntities())
+            event.setCancelled(true);
     }
 
     @EventHandler

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Settings.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Settings.java
@@ -17,7 +17,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 public class Settings {
 
 	private boolean commandPermission, chatPrefix, disablePlayerDamage, resetOnLeave, enforceWorld, disableCommands,
-            allowTrails, signPermission, attemptLessChecks, useParkourKit;
+            allowTrails, signPermission, attemptLessChecks, useParkourKit, preventAttackingEntities;
 
 	//Display
 	private boolean displayWelcome;
@@ -43,6 +43,7 @@ public class Settings {
 		signPermission = config.getBoolean("Other.Parkour.SignPermissions");
 		attemptLessChecks = config.getBoolean("OnCourse.AttemptLessChecks");
         useParkourKit = config.getBoolean("OnCourse.UseParkourKit");
+        preventAttackingEntities = config.getBoolean("OnCourse.PreventAttackingEntities");
 
 		lastCheckpoint = Material.getMaterial(config.getString("OnJoin.Item.LastCheckpoint.Material"));
 		hideall = Material.getMaterial(config.getString("OnJoin.Item.HideAll.Material"));
@@ -93,6 +94,10 @@ public class Settings {
 
 	public boolean isDisplayWelcome() {
 		return displayWelcome;
+	}
+
+	public boolean isPreventAttackingEntities() {
+		return preventAttackingEntities;
 	}
 
 	public Material getLastCheckpoint() {


### PR DESCRIPTION
Currently, players can attack and kill other entities while playing in a course.
This pull request adds an option to block this if desired (see issue #75).
This does not prevent players from interacting with other entities.
