### PR TITLE
save lobby location as doubles when upgrading to new parkour version

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Conversation/other/AddKitItemConversation.java
+++ b/src/main/java/me/A5H73Y/Parkour/Conversation/other/AddKitItemConversation.java
@@ -146,10 +146,10 @@ public class AddKitItemConversation {
             config.set(path + ".Action", action);
 
             if (hasStrength) {
-                config.set(path + ".Strength", context.getSessionData("strength").toString());
+                config.set(path + ".Strength", context.getSessionData("strength"));
             }
             if (hasDuration) {
-                config.set(path + ".Duration", context.getSessionData("duration").toString());
+                config.set(path + ".Duration", context.getSessionData("duration"));
             }
 
             Parkour.getParkourConfig().saveParkourKit();

--- a/src/main/java/me/A5H73Y/Parkour/Other/StartPlugin.java
+++ b/src/main/java/me/A5H73Y/Parkour/Other/StartPlugin.java
@@ -292,10 +292,10 @@ public class StartPlugin {
     private static void setLobbyData(String[] lobbyData) {
         Parkour.getPlugin().getConfig().set("Lobby.Set", true);
         Parkour.getPlugin().getConfig().set("Lobby.World", lobbyData[0]);
-        Parkour.getPlugin().getConfig().set("Lobby.X", lobbyData[1]);
-        Parkour.getPlugin().getConfig().set("Lobby.Y", lobbyData[2]);
-        Parkour.getPlugin().getConfig().set("Lobby.Z", lobbyData[3]);
-        Parkour.getPlugin().getConfig().set("Lobby.Pitch", lobbyData[4]);
-        Parkour.getPlugin().getConfig().set("Lobby.Yaw", lobbyData[5]);
+        Parkour.getPlugin().getConfig().set("Lobby.X", Double.valueOf(lobbyData[1]));
+        Parkour.getPlugin().getConfig().set("Lobby.Y", Double.valueOf(lobbyData[2]));
+        Parkour.getPlugin().getConfig().set("Lobby.Z", Double.valueOf(lobbyData[3]));
+        Parkour.getPlugin().getConfig().set("Lobby.Pitch", Double.valueOf(lobbyData[4]));
+        Parkour.getPlugin().getConfig().set("Lobby.Yaw", Double.valueOf(lobbyData[5]));
     }
 }


### PR DESCRIPTION
Should prevent the 'no lobby' issue after upgrading.
Strength and duration should be saved as numeric not strings.