### PR TITLE
restore player inventory before teleporting

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
@@ -171,6 +171,8 @@ public class PlayerMethods {
      * Player finishes a course
      * This will be called when the player completes the course.
      * Their reward will be given here, as well as a time entry to the database.
+     * Inventory is restored before the player is teleported. If the teleport is delayed,
+     * restore the inventory after the delay.
      *
      * @param player
      */
@@ -207,17 +209,19 @@ public class PlayerMethods {
 
         if (Parkour.getPlugin().getConfig().getBoolean("OnDie.SetXPBarToDeathCount"))
             player.setLevel(0);
-
-        loadInventory(player);
-        givePrize(player, courseName);
         
+        Long delay = Parkour.getPlugin().getConfig().getLong("OnFinish.TeleportDelay");
+        if (delay <= 0 || !Parkour.getPlugin().getConfig().getBoolean("OnFinish.TeleportAway")) {
+            loadInventory(player);
+            givePrize(player, courseName);
+        }
         if (Parkour.getPlugin().getConfig().getBoolean("OnFinish.TeleportAway")) {
-            Long delay = Parkour.getPlugin().getConfig().getLong("OnFinish.TeleportDelay");
-
             if (delay > 0) {
                 Bukkit.getScheduler().scheduleSyncDelayedTask(Parkour.getPlugin(), new Runnable() {
                     public void run() {
-                        courseCompleteLocation(player, courseName);
+                    	loadInventory(player);
+                    	givePrize(player, courseName);
+                    	courseCompleteLocation(player, courseName);
                     }
                 }, delay);
 

--- a/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
@@ -208,6 +208,9 @@ public class PlayerMethods {
         if (Parkour.getPlugin().getConfig().getBoolean("OnDie.SetXPBarToDeathCount"))
             player.setLevel(0);
 
+        loadInventory(player);
+        givePrize(player, courseName);
+        
         if (Parkour.getPlugin().getConfig().getBoolean("OnFinish.TeleportAway")) {
             Long delay = Parkour.getPlugin().getConfig().getLong("OnFinish.TeleportDelay");
 
@@ -222,9 +225,6 @@ public class PlayerMethods {
                 courseCompleteLocation(player, courseName);
             }
         }
-
-        loadInventory(player);
-        givePrize(player, courseName);
 
         if (Parkour.getPlugin().getConfig().getBoolean("OnFinish.UpdatePlayerDatabaseTime")) {
             DatabaseMethods.updateTime(courseName, player, timeTaken, session.getDeaths());


### PR DESCRIPTION
Affects linked courses and multiword servers. Ensures inventory is restored and prize given before player is teleported to a linked course otherwise restoring it afterwards will overwrite the Parkour items in the hotbar.
If the player is teleported to a lobby in another world, its likely that the players original inventory in the departing world will be left overwritten by the 3 parkour items.

This reverts part of commit ebba020.

Similar to issue #11 