### PR TITLE
fixes npe if kit name includes uppercase chars

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Conversation/CreateParkourKitConversation.java
+++ b/src/main/java/me/A5H73Y/Parkour/Conversation/CreateParkourKitConversation.java
@@ -26,7 +26,7 @@ public class CreateParkourKitConversation extends StringPrompt {
             return Prompt.END_OF_CONVERSATION;
         }
 
-        name = name.toLowerCase();
+        name = name.toLowerCase().replace(' ', '_');
 
         if (Parkour.getParkourConfig().getParkourKitData().contains("ParkourKit." + name)){
             ParkourConversation.sendErrorMessage(context, "This ParkourKit already exists");

--- a/src/main/java/me/A5H73Y/Parkour/Conversation/CreateParkourKitConversation.java
+++ b/src/main/java/me/A5H73Y/Parkour/Conversation/CreateParkourKitConversation.java
@@ -26,7 +26,12 @@ public class CreateParkourKitConversation extends StringPrompt {
             return Prompt.END_OF_CONVERSATION;
         }
 
-        name = name.toLowerCase().replace(' ', '_');
+        if (name.contains(" ")) {
+        	ParkourConversation.sendErrorMessage(context, "The ParkourKit name cannot include spaces");
+        	return this;
+        }
+        
+        name = name.toLowerCase();
 
         if (Parkour.getParkourConfig().getParkourKitData().contains("ParkourKit." + name)){
             ParkourConversation.sendErrorMessage(context, "This ParkourKit already exists");

--- a/src/main/java/me/A5H73Y/Parkour/Other/ParkourKit.java
+++ b/src/main/java/me/A5H73Y/Parkour/Other/ParkourKit.java
@@ -121,7 +121,10 @@ public class ParkourKit implements Serializable {
      * @return ParkourKit
      */
     public static ParkourKit getParkourKit(String name) {
-        if (loaded.containsKey(name)) {
+        
+    	name = name.toLowerCase();
+    	
+    	if (loaded.containsKey(name)) {
             return loaded.get(name);
         }
 

--- a/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
@@ -568,7 +568,7 @@ public class PlayerMethods {
         ParkourKit kit;
 
         if (args != null && args.length == 2) {
-            kit = ParkourKit.getParkourKit(args[1].toLowerCase());
+            kit = ParkourKit.getParkourKit(args[1]);
             if (kit == null) {
                 player.sendMessage(Static.getParkourString() + "Invalid ParkourKit: " + ChatColor.RED + args[1]);
                 return;

--- a/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
@@ -568,7 +568,7 @@ public class PlayerMethods {
         ParkourKit kit;
 
         if (args != null && args.length == 2) {
-            kit = ParkourKit.getParkourKit(args[1]);
+            kit = ParkourKit.getParkourKit(args[1].toLowerCase());
             if (kit == null) {
                 player.sendMessage(Static.getParkourString() + "Invalid ParkourKit: " + ChatColor.RED + args[1]);
                 return;


### PR DESCRIPTION
Only affects "/pa kit" command when a valid kit is specified with any uppercase letters, e.g. "/pa kit Default". Kit names are converted to lowercase on creation, so need to be converted.

The createkit conversation allows kit names to include spaces, which are written correctly to the yml file, but the space causes problems with some commands, e.g. "/pa kit" which ignores the space and gives the default kit.
We could strip the spaces from the name, reject it as invalid, or replace the spaces with a '_'.  I went for the latter, but now I'm thinking maybe reject it as invalid might be better - let me know if you want it changed.
  