### PR TITLE
Correct pagination in "list courses" and check page number is integer

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
@@ -293,7 +293,7 @@ public class CourseMethods {
             displayPlaying(sender);
 
         } else if (args[1].equalsIgnoreCase("courses")) {
-            int page = (args.length == 3 && args[2] != null ? Integer.parseInt(args[2]) : 1);
+            int page = (args.length == 3 && args[2] != null && Utils.isNumber(args[2]) ? Integer.parseInt(args[2]) : 1);
             displayCourses(sender, page);
 
         } else {

--- a/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
@@ -339,26 +339,27 @@ public class CourseMethods {
             return;
         }
 
+        int results = 8;
         List<String> courseList = Static.getCourses();
         if (page <= 0) {
             sender.sendMessage(Static.getParkourString() + "Please enter a valid page number.");
             return;
         }
 
-        int fromIndex = (page - 1) * 8;
-        if (courseList.size() < fromIndex) {
+        int fromIndex = (page - 1) * results;
+        if (courseList.size() <= fromIndex) {
             sender.sendMessage(Static.getParkourString() + "This page doesn't exist.");
             return;
         }
 
         sender.sendMessage(Static.getParkourString() + courseList.size() + " courses available:");
-        List<String> limited = courseList.subList(fromIndex, Math.min(fromIndex + 8, courseList.size()));
+        List<String> limited = courseList.subList(fromIndex, Math.min(fromIndex + results, courseList.size()));
 
         for (int i = 0; i < limited.size(); i++) {
             sender.sendMessage(((fromIndex) + (i + 1)) + ") " + ChatColor.AQUA + limited.get(i));
         }
 
-        sender.sendMessage("== " + page + " / " + ((courseList.size() / 8) + 1) + " ==");
+        sender.sendMessage("== " + page + " / " + ((courseList.size() + results - 1) / results) + " ==");
     }
 
     /**

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Static.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Static.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Set;
 
 import me.A5H73Y.Parkour.Parkour;
-import me.A5H73Y.Parkour.Other.Challenge;
 import me.A5H73Y.Parkour.Other.Question;
 
 import org.bukkit.entity.Player;
@@ -146,6 +145,7 @@ public final class Static {
 
 		lobbyListSet.remove("Set");
 		lobbyListSet.remove("World");
+		lobbyListSet.remove("EnforceWorld");
 		lobbyListSet.remove("X");
 		lobbyListSet.remove("Y");
 		lobbyListSet.remove("Z");


### PR DESCRIPTION
Example "/pa list courses" with 32 courses:

![2018-01-30_11 54 51_2](https://user-images.githubusercontent.com/6975392/35582539-08c31700-05e7-11e8-919b-a10c60614145.png)
 
If the number of courses you have is an exact multiple of 8, then it incorrectly calculates the number of pages giving an empty final page.

You get an NPE if you list courses by page number and give a non-integer as the page number, e.g. "/pa list courses abc"