### PR TITLE
add cool-down for course reward

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Course/CourseInfo.java
+++ b/src/main/java/me/A5H73Y/Parkour/Course/CourseInfo.java
@@ -215,6 +215,15 @@ public class CourseInfo {
         Parkour.getParkourConfig().getUsersData().set("ServerInfo.Levels." + level + ".Rank", rank);
         Parkour.getParkourConfig().saveUsers();
     }
+    
+    public static int getRewardDelay(String courseName) {
+    	return Parkour.getParkourConfig().getCourseData().getInt(courseName.toLowerCase() + ".RewardDelay");
+    }
+    
+    public static void setRewardDelay(String courseName, String rewardDelay) {
+    	Parkour.getParkourConfig().getCourseData().set(courseName.toLowerCase() + ".RewardDelay", Integer.parseInt(rewardDelay));
+        Parkour.getParkourConfig().saveCourses();
+    }
 
     public static int getRewardParkoins(String courseName) {
         return Parkour.getParkourConfig().getCourseData().getInt(courseName.toLowerCase() + ".Parkoins");

--- a/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
@@ -571,12 +571,32 @@ public class CourseMethods {
         }
 
         if (args[2] == null || args[2].trim().length() == 0) {
-            sender.sendMessage(Static.getParkourString() + "Rank is not valid");
+            sender.sendMessage(Static.getParkourString() + "Rank is not valid.");
             return;
         }
 
         CourseInfo.setRewardRank(args[1], args[2]);
         sender.sendMessage(Static.getParkourString() + "Level " + args[1] + "'s rank was set to " + Utils.colour(args[2]));
+    }
+    
+    /**
+     * Set the number of days that have to elapse before the prize can be won again by the same player.
+     *
+     * @param args
+     * @param sender
+     */
+    public static void setRewardDelay(String[] args, CommandSender sender) {
+    	if (!CourseMethods.exist(args[1])) {
+            sender.sendMessage(Utils.getTranslation("Error.NoExist").replace("%COURSE%", args[1]));
+            return;
+        }
+    	if (!Utils.isNumber(args[2])) {
+            sender.sendMessage(Static.getParkourString() + "Reward delay needs to be numeric.");
+            return;
+        }
+    	
+    	CourseInfo.setRewardDelay(args[1], args[2]);
+    	sender.sendMessage(Static.getParkourString() + args[1] + "'s reward delay was set to " + Utils.colour(args[2]) + " day(s).");
     }
 
     /**

--- a/src/main/java/me/A5H73Y/Parkour/Other/Help.java
+++ b/src/main/java/me/A5H73Y/Parkour/Other/Help.java
@@ -181,6 +181,10 @@ public final class Help {
 			displayHelpMessage(sender, "Reward Parkoins", "/pa rewardparkoins (course) (amount)", "/pa rewardparkoins tutorial 10",
 					" You can reward a player with Parkoins for completing a course. These can be spent in the store to unlock additional content which would be unobtainable without the minimum amount of Parkoins required.");
 
+		} else if (args[1].equalsIgnoreCase("rewarddelay")){	
+			displayHelpMessage(sender, "Reward Delay/Frequency for course", "/pa rewarddelay (course) (delay)", "/pa rewarddelay tutorial 1",
+					" Limit a course reward for a player to once per day, as in the example. The rate at which the reward is given, is achieved by setting the delay to the number of days which need to elapse before the player can win the same prize again.");
+		
 		} else if (args[1].equalsIgnoreCase("recreate")){	
 			displayHelpMessage(sender, "Recreate course database", "/pa recreate", null,
 					" Used to fix the database if there are missing courses that haven't been synchronised with the server.");
@@ -399,6 +403,7 @@ public final class Help {
 		displayCommandUsage(player, "rewardleveladd", "(course) (amount)", "Reward level addon");
 		displayCommandUsage(player, "rewardrank", "(level) (rank)", "Reward rank on complete");
 		displayCommandUsage(player, "rewardparkoins", "(course) (amount)", "Reward Parkoins");
+		displayCommandUsage(player, "rewarddelay", "(course) (delay)", "Reward cool-down (days)");
 	}
 
 	/**

--- a/src/main/java/me/A5H73Y/Parkour/ParkourCommands.java
+++ b/src/main/java/me/A5H73Y/Parkour/ParkourCommands.java
@@ -232,6 +232,15 @@ class ParkourCommands implements CommandExecutor {
 
 						CourseMethods.setRewardRank(args, player);
 
+					} else if (args[0].equalsIgnoreCase("rewarddelay")) {
+						if (!Utils.hasPermission(player, "Parkour.Admin"))
+							return false;
+
+						if (!Utils.validateArgs(player, args, 3))
+							return false;
+
+						CourseMethods.setRewardDelay(args, player);
+					
 					} else if (args[0].equalsIgnoreCase("rewardparkoins")) {
 						if (!Utils.hasPermission(player, "Parkour.Admin"))
 							return false;

--- a/src/main/java/me/A5H73Y/Parkour/Player/PlayerInfo.java
+++ b/src/main/java/me/A5H73Y/Parkour/Player/PlayerInfo.java
@@ -152,6 +152,27 @@ public class PlayerInfo {
         Parkour.getParkourConfig().getUsersData().set("PlayerInfo." + player.getName() + ".Rank", rank);
         Parkour.getParkourConfig().saveUsers();
     }
+    
+    /**
+     * Get the time the player last won the reward for the course
+     * @param player
+     * @param courseName
+     * @return
+     */
+    public static long getRewardTime(OfflinePlayer player, String courseName) {
+    	return Parkour.getParkourConfig().getUsersData().getLong("PlayerInfo." + player.getName() + ".Prizes." + courseName);
+    }
+    
+    /**
+     * Set the time the player wins the reward for the course
+     * @param player
+     * @param courseName
+     * @param rewardTime
+     */
+    public static void setRewardTime(OfflinePlayer player, String courseName, long rewardTime) {
+    	Parkour.getParkourConfig().getUsersData().set("PlayerInfo." + player.getName() + ".Prizes." + courseName, rewardTime);
+    	Parkour.getParkourConfig().saveUsers();
+    }
 
     /**
      * Determine if the Parkour has any saved information about a player

--- a/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
@@ -316,6 +316,14 @@ public class PlayerMethods {
                 DatabaseMethods.hasPlayerCompleted(player.getName(), courseName))
             return;
 
+        // Check how often prize can be rewarded
+        if (CourseInfo.getRewardDelay(courseName) > 0) {
+        	if (!Utils.canRewardPrize(player, courseName)) {
+        		return;
+        	}
+        	PlayerInfo.setRewardTime(player, courseName, System.currentTimeMillis());
+        }
+        
         Material material;
         int amount;
 

--- a/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
@@ -415,7 +415,7 @@ public class PlayerMethods {
         PlayerInfo.setParkoins(player, total);
         player.sendMessage(Utils.getTranslation("Parkour.RewardParkoins")
                 .replace("%AMOUNT%", String.valueOf(parkoins))
-                .replace("%TOTAL", String.valueOf(total)));
+                .replace("%TOTAL%", String.valueOf(total)));
     }
 
     /**

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Utils.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Utils.java
@@ -204,10 +204,10 @@ public final class Utils {
     }
 
     /**
-     * Convert milliseconds into formatted time HH:MM:SS(.sss)
+     * Convert milliseconds into formatted time (DD:)HH:MM:SS(.sss)
      *
      * @param millis
-     * @return formatted time: HH:MM:SS.(sss)
+     * @return formatted time: (DD:)HH:MM:SS.(sss)
      */
     public static String calculateTime(long millis) {
         long hours = millis / (3600 * 1000);
@@ -218,7 +218,11 @@ public final class Utils {
             long milliseconds = millis % 1000;
     		return String.format("%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds);
     	}
-        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    	if (hours < 24) {
+    		return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    	}
+    	long days = millis / (3600 * 1000 * 24);
+        return String.format("%02d:%02d:%02d:%02d", days, hours % 24, minutes, seconds);
     }
 
     /**
@@ -911,6 +915,22 @@ public final class Utils {
 			}
 		}
     	return true;
+    }
+    
+    public static boolean canRewardPrize(Player player, String courseName) {
+    	int rewardDelay = CourseInfo.getRewardDelay(courseName);
+    	long currTime = System.currentTimeMillis();
+    	long lastTime = PlayerInfo.getRewardTime(player, courseName);
+    	if (currTime - lastTime > rewardDelay*24*60*60*1000) {
+    		return true;
+    	}
+    	String[] waitTime = Utils.calculateTime((rewardDelay*24*60*60*1000) - (currTime - lastTime)).split(":");
+    	if (waitTime.length == 4) {
+    		player.sendMessage(Static.getParkourString() + "You will have to wait " + ChatColor.AQUA + waitTime[0] + ":" + waitTime[1] + ":" + waitTime[2] + ":" + waitTime[3] + ChatColor.WHITE + " before you can receive this prize again.");
+    	} else {
+    		player.sendMessage(Static.getParkourString() + "You will have to wait " + ChatColor.AQUA + waitTime[0] + ":" + waitTime[1] + ":" + waitTime[2] + ChatColor.WHITE  + " before you can receive this prize again.");
+    	}
+    	return false;
     }
 
     public static Material getMaterial(String name) {

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Utils.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Utils.java
@@ -204,10 +204,10 @@ public final class Utils {
     }
 
     /**
-     * Convert milliseconds into formatted time (DD:)HH:MM:SS(.sss)
+     * Convert milliseconds into formatted time HH:MM:SS(.sss)
      *
      * @param millis
-     * @return formatted time: (DD:)HH:MM:SS.(sss)
+     * @return formatted time: HH:MM:SS.(sss)
      */
     public static String calculateTime(long millis) {
         long hours = millis / (3600 * 1000);
@@ -216,13 +216,9 @@ public final class Utils {
 
     	if (Parkour.getSettings().isDisplayMilliseconds()) {
             long milliseconds = millis % 1000;
-    		return String.format("%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds);
+            return String.format("%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds);
     	}
-    	if (hours < 24) {
-    		return String.format("%02d:%02d:%02d", hours, minutes, seconds);
-    	}
-    	long days = millis / (3600 * 1000 * 24);
-        return String.format("%02d:%02d:%02d:%02d", days, hours % 24, minutes, seconds);
+    	return String.format("%02d:%02d:%02d", hours, minutes, seconds);
     }
 
     /**
@@ -925,10 +921,11 @@ public final class Utils {
     		return true;
     	}
     	String[] waitTime = Utils.calculateTime((rewardDelay*24*60*60*1000) - (currTime - lastTime)).split(":");
-    	if (waitTime.length == 4) {
-    		player.sendMessage(Static.getParkourString() + "You will have to wait " + ChatColor.AQUA + waitTime[0] + ":" + waitTime[1] + ":" + waitTime[2] + ":" + waitTime[3] + ChatColor.WHITE + " before you can receive this prize again.");
+    	int hours = Integer.valueOf(waitTime[0]);
+    	if (hours > 48) {
+    		player.sendMessage(Static.getParkourString() + "You have to wait " + ChatColor.AQUA + (hours / 24) + " days before you can receive this prize again.");
     	} else {
-    		player.sendMessage(Static.getParkourString() + "You will have to wait " + ChatColor.AQUA + waitTime[0] + ":" + waitTime[1] + ":" + waitTime[2] + ChatColor.WHITE  + " before you can receive this prize again.");
+    		player.sendMessage(Static.getParkourString() + "You have to wait " + ChatColor.AQUA + waitTime[0] + ":" + waitTime[1] + ":" + waitTime[2].substring(0, Math.min(2, waitTime[2].length())) + ChatColor.WHITE  + " before you can receive this prize again.");
     	}
     	return false;
     }


### PR DESCRIPTION
Fixes #20 - ability to limit prize to once per day - by adding a "reward delay" to the course, which is specified in days.

Fixes small bug - when rewarded with parkoins, message appends a"%" symbol to the new total.

