### PR TITLE
remove course from courseList on deletion

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Course/CourseInfo.java
+++ b/src/main/java/me/A5H73Y/Parkour/Course/CourseInfo.java
@@ -457,9 +457,10 @@ public class CourseInfo {
     public static void deleteCourse(String courseName) {
         courseName = courseName.toLowerCase();
 
-        getAllCourses().remove(courseName);
+        List<String> courseList = getAllCourses();
+        courseList.remove(courseName);
         Parkour.getParkourConfig().getCourseData().set(courseName, null);
-        Parkour.getParkourConfig().getCourseData().set("Courses", getAllCourses());
+        Parkour.getParkourConfig().getCourseData().set("Courses", courseList);
         Parkour.getParkourConfig().saveCourses();
         DatabaseMethods.deleteCourseAndReferences(courseName);
     }

--- a/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
@@ -140,9 +140,9 @@ public class CourseMethods {
         courseData.set(name + ".0.Yaw", location.getYaw());
         courseData.set(name + ".0.Pitch", location.getPitch());
 
-        List<String> courses = CourseInfo.getAllCourses();
-        courses.add(name);
-        courseData.set("Courses", courses);
+        List<String> courseList = CourseInfo.getAllCourses();
+        courseList.add(name);
+        courseData.set("Courses", courseList);
         Parkour.getParkourConfig().saveCourses();
 
         PlayerInfo.setSelected(player, name);

--- a/src/main/java/me/A5H73Y/Parkour/Other/Configurations.java
+++ b/src/main/java/me/A5H73Y/Parkour/Other/Configurations.java
@@ -3,8 +3,6 @@ package me.A5H73Y.Parkour.Other;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-
 import me.A5H73Y.Parkour.Parkour;
 import me.A5H73Y.Parkour.Utilities.Static;
 import me.A5H73Y.Parkour.Utilities.Utils;

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Settings.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Settings.java
@@ -100,7 +100,6 @@ public class Settings {
 	}
 
 	public Material getLeaveTool() {
-		//Material leaveTool = Material.getMaterial(config.getString("OnJoin.Item.Leave.Material"));
 		Material leaveTool = XMaterial.fromString(config.getString("OnJoin.Item.Leave.Material")).parseMaterial();
         return leaveTool == Material.AIR ? null : leaveTool;
 	}

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Settings.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Settings.java
@@ -100,7 +100,8 @@ public class Settings {
 	}
 
 	public Material getLeaveTool() {
-		Material leaveTool = Material.getMaterial(config.getString("OnJoin.Item.Leave.Material"));
+		//Material leaveTool = Material.getMaterial(config.getString("OnJoin.Item.Leave.Material"));
+		Material leaveTool = XMaterial.fromString(config.getString("OnJoin.Item.Leave.Material")).parseMaterial();
         return leaveTool == Material.AIR ? null : leaveTool;
 	}
 

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Utils.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Utils.java
@@ -893,7 +893,7 @@ public final class Utils {
             validMaterials.add(Material.PURPUR_SLAB);
         }
         //check if player is standing in a half-block
-        if (! block.getType().equals(Material.AIR) && ! block.getType().equals(XMaterial.STONE_PRESSURE_PLATE.parseMaterial())) {
+        if (! block.getType().equals(Material.AIR) && ! block.getType().equals(XMaterial.fromString(Parkour.getPlugin().getConfig().getString("OnCourse.CheckpointMaterial")).parseMaterial())) {
             player.sendMessage(Static.getParkourString() + "Invalid block for checkpoint: " + ChatColor.AQUA + block.getType());
             return false;
         }


### PR DESCRIPTION
Same as #108 really. Course list is not updated when a course is deleted.
Made list name consistent with other calls to getAllCourses().

Restore missing sapling on 1.13.

Since #106, checkpoints can be any pressure plate type. Only STONE_PLATES could be re-numbered.