### PR TITLE
Update safe checkpoints

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Other/ParkourKit.java
+++ b/src/main/java/me/A5H73Y/Parkour/Other/ParkourKit.java
@@ -49,7 +49,6 @@ public class ParkourKit implements Serializable {
             String action = Parkour.getParkourConfig().getParkourKitData()
                     .getString("ParkourKit." + name + "." + rawMaterial + ".Action").toLowerCase();
 
-            Bukkit.getLogger().info("ParkourKit: action = " + action);
             if (!validActions.contains(action)) {
                 Utils.log("Action " + action + " is invalid.", 1);
                 continue;

--- a/src/main/java/me/A5H73Y/Parkour/Other/ParkourKit.java
+++ b/src/main/java/me/A5H73Y/Parkour/Other/ParkourKit.java
@@ -5,6 +5,8 @@ import java.util.*;
 
 import me.A5H73Y.Parkour.Parkour;
 import me.A5H73Y.Parkour.Utilities.Utils;
+
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 
@@ -43,10 +45,11 @@ public class ParkourKit implements Serializable {
                 Utils.log("Material " + rawMaterial + " is invalid.", 1);
                 continue;
             }
-
+            
             String action = Parkour.getParkourConfig().getParkourKitData()
-                    .getString("ParkourKit." + name + "." + material.name() + ".Action").toLowerCase();
+                    .getString("ParkourKit." + name + "." + rawMaterial + ".Action").toLowerCase();
 
+            Bukkit.getLogger().info("ParkourKit: action = " + action);
             if (!validActions.contains(action)) {
                 Utils.log("Action " + action + " is invalid.", 1);
                 continue;

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Utils.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Utils.java
@@ -889,7 +889,13 @@ public final class Utils {
         List<Material> validMaterials = new ArrayList<>();
 
         Collections.addAll(validMaterials, Material.AIR, Material.REDSTONE_BLOCK,
-                XMaterial.STONE_SLAB.parseMaterial(), XMaterial.OAK_SLAB.parseMaterial(), XMaterial.RED_SANDSTONE_SLAB.parseMaterial());
+        		XMaterial.ACACIA_SLAB.parseMaterial(), XMaterial.BIRCH_SLAB.parseMaterial(), XMaterial.BRICK_SLAB.parseMaterial(),
+        		XMaterial.COBBLESTONE_SLAB.parseMaterial(), XMaterial.DARK_OAK_SLAB.parseMaterial(), XMaterial.DARK_PRISMARINE_SLAB.parseMaterial(),
+        		XMaterial.JUNGLE_SLAB.parseMaterial(), XMaterial.NETHER_BRICK_SLAB.parseMaterial(), XMaterial.OAK_SLAB.parseMaterial(),
+                XMaterial.PETRIFIED_OAK_SLAB.parseMaterial(), XMaterial.PRISMARINE_BRICK_SLAB.parseMaterial(), XMaterial.PRISMARINE_SLAB.parseMaterial(),
+                XMaterial.QUARTZ_SLAB.parseMaterial(), XMaterial.RED_SANDSTONE_SLAB.parseMaterial(), XMaterial.SANDSTONE_SLAB.parseMaterial(),
+                XMaterial.SPRUCE_SLAB.parseMaterial(), XMaterial.STONE_BRICK_SLAB.parseMaterial(), XMaterial.STONE_SLAB.parseMaterial());
+        
         if (!Bukkit.getBukkitVersion().contains("1.8")) {
             validMaterials.add(Material.PURPUR_SLAB);
         }


### PR DESCRIPTION
Update the list of (top) slabs that checkpoints can be created on. Checked on 1.8 - 1.12.2 that Xmaterial correctly renames them.

I think there's a small typo in ParkourKit where the config key to get the 'action' should be the rawMaterial name.