### PR TITLE
Add title message for course records

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Other/Configurations.java
+++ b/src/main/java/me/A5H73Y/Parkour/Other/Configurations.java
@@ -322,7 +322,8 @@ public class Configurations {
             stringData.addDefault("Parkour.SetMode", "Mode for &b%COURSE% &fset to &b%MODE%");
             stringData.addDefault("Parkour.Countdown", "Starting in &b%AMOUNT% &fseconds...");
             stringData.addDefault("Parkour.Go", "Go!");
-            stringData.addDefault("Parkour.BestTime", "This is your best time so far!");
+            stringData.addDefault("Parkour.BestTime", "Your new best time!");
+            stringData.addDefault("Parkour.CourseRecord", "New course record!");
             stringData.addDefault("Parkour.LeaderboardHeading", "%COURSE% : Top %AMOUNT% results");
             stringData.addDefault("Parkour.LeaderboardEntry", "%POSITION%) &b%PLAYER% &fin &3%TIME%&f, dying &7%DEATHS% &ftimes");
             stringData.addDefault("Parkour.QuietOn", "Quiet Mode: &bON");

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/DatabaseMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/DatabaseMethods.java
@@ -10,6 +10,7 @@ import me.A5H73Y.Parkour.Course.CourseInfo;
 import me.A5H73Y.Parkour.Parkour;
 import me.A5H73Y.Parkour.Enums.DatabaseType;
 import me.A5H73Y.Parkour.Other.TimeObject;
+import me.A5H73Y.Parkour.Player.PlayerMethods;
 
 import org.bukkit.Bukkit;
 
@@ -127,7 +128,7 @@ public class DatabaseMethods {
      * @param time
      * @param deaths
      */
-    public static void insertTime(String courseName, String playerName, long time, int deaths) {
+    private static void insertTime(String courseName, String playerName, long time, int deaths) {
         try {
             int courseId = getCourseId(courseName);
             if (courseId == 0)
@@ -148,21 +149,16 @@ public class DatabaseMethods {
     }
 
     public static void updateTime(String courseName, Player player, long time, int deaths) {
-        List<TimeObject> results = getTopPlayerCourseResults(player.getName(), courseName, 1);
-
-        if (results == null || results.isEmpty()) {
-            insertTime(courseName, player.getName(), time, deaths);
-            return;
-        }
-
-        TimeObject result = results.get(0);
-
-        if (result.getTime() <= time)
-            return;
-
-        player.sendMessage(Utils.getTranslation("Parkour.BestTime"));
-        deletePlayerCourseTimes(player.getName(), courseName);
-        insertTime(courseName, player.getName(), time, deaths);
+    	if (PlayerMethods.isNewRecord(player, courseName, time)) {
+    		if (Parkour.getPlugin().getConfig().getBoolean("OnFinish.UpdatePlayerDatabaseTime")) {
+    			deletePlayerCourseTimes(player.getName(), courseName);
+    			insertTime(courseName, player.getName(), time, deaths);
+    			return;
+    		}
+    	}
+    	if (!Parkour.getPlugin().getConfig().getBoolean("OnFinish.UpdatePlayerDatabaseTime")) {
+    		insertTime(courseName, player.getName(), time, deaths);
+    	}
     }
 
     /**


### PR DESCRIPTION
 #113 and the issue where the 'new best time' message is only displayed if  ```UpdatePlayerDatabaseTime```  is set to true.

Added ```isNewRecord``` method to compare time against DB and send the relevant title message if appropriate.
I had to shorten the Parkour.BestTime string so the title message fits on the screen.

So, if ```UpdatePlayerDatabaseTime``` is true or false you should now get a "New Course Record" or "New Best Time" title message when the corresponding database time has been beaten. (Excluding the trivial cases when the course or player doesn't have a previous time).
