### PR TITLE
add auto tab completion

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Course/CourseMethods.java
@@ -380,9 +380,9 @@ public class CourseMethods {
     }
 
     /**
-     * Set the course prize
-     * Starts a Prize conversation that allows you to configure what the player gets awarded with when the complete the course.
-     * A course could have every type of Prize if setup.
+     * Create an auto-start for a course
+     * Create an auto-start at the player's location for the specified course.
+     * Save the auto-start coordinates.
      *
      * @param args
      * @param player

--- a/src/main/java/me/A5H73Y/Parkour/Parkour.java
+++ b/src/main/java/me/A5H73Y/Parkour/Parkour.java
@@ -63,6 +63,7 @@ public class Parkour extends JavaPlugin {
 
     private void registerCommands() {
         getCommand("parkour").setExecutor(new ParkourCommands());
+        getCommand("parkour").setTabCompleter(new ParkourAutoTabCompleter());
     }
 
 	public static Configurations getParkourConfig() {

--- a/src/main/java/me/A5H73Y/Parkour/ParkourAutoTabCompleter.java
+++ b/src/main/java/me/A5H73Y/Parkour/ParkourAutoTabCompleter.java
@@ -1,0 +1,205 @@
+package me.A5H73Y.Parkour;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import me.A5H73Y.Parkour.Course.CourseInfo;
+import me.A5H73Y.Parkour.Player.PlayerInfo;
+import me.A5H73Y.Parkour.Utilities.Utils;
+
+public class ParkourAutoTabCompleter implements TabCompleter {
+	
+	@Override
+	public List<String> onTabComplete(CommandSender sender, Command cmd, String alias, String[] args) {
+		if (!(sender instanceof Player)) {
+			return null;
+		}
+		
+		List<String> list = new ArrayList<String>();
+		List<String> auto = new ArrayList<String>();
+		List<String> courseCmds = getCourseCmds(sender);
+		List<String> basicCmds = Arrays.asList("challenge", "leaderboard", "invite", "kit", "kitlist", "tp", "tpc");
+		List<String> adminCmds = Arrays.asList("setstart", "setlobby", "economy", "createkit", "editkit", "validatekit", "recreate", 
+				"sql", "settings", "reload", "rewardrank", "whitelist", "setlevel", "setrank", "delete"); 
+		
+		if (args.length == 1) {
+			list.add("help");
+			list.add("info");
+			list.add("contact");
+			list.add("about");
+			list.add("version");
+			list.add("material");
+			list.add("quiet");
+			list.add("like");
+			list.add("dislike");
+			list.add("list");
+			list.add("lobby");
+			list.add("perms");
+			list.add("leave");
+			list.add("done");
+			list.add("tutorial");
+			list.add("request");
+			list.add("accept");
+			list.add("bug");
+			list.add("cmds");
+			list.add("create");
+			
+			if (sender.hasPermission("Parkour.Basic.*") || sender.hasPermission("Parkour.*")) {
+				list.addAll(basicCmds);
+			} else {
+				if (sender.hasPermission("Parkour.Basic.Create")) {
+					list.add("create");
+				}
+				if (sender.hasPermission("Parkour.Basic.Invite")) {
+					list.add("invite");
+				}
+				if (sender.hasPermission("Parkour.Basic.Kit")) {
+					list.add("kit");
+					list.add("listkit");
+				}
+				if (sender.hasPermission("Parkour.Basic.Challenge")) {
+					list.add("challenge");
+				}
+				if (sender.hasPermission("Parkour.Basic.TPC")) {
+					list.add("tpc");
+				}
+				if (sender.hasPermission("Parkour.Basic.TP")) {
+					list.add("tp");
+				}
+				if (sender.hasPermission("Parkour.Basic.Leaderboard")) {
+					list.add("leaderboard");
+				}
+			}
+			
+			if (sender.hasPermission("Parkour.Admin") || sender.hasPermission("Parkour.*")) {
+				list.addAll(adminCmds);
+			}
+			if (sender.hasPermission("Parkour.Admin.*") || sender.hasPermission("Parkour.*")) {
+				list.add("test");
+				list.add("reset");
+				list.add("delete");
+				list.add("checkpoint");
+				list.add("link");
+			} else {
+				if (sender.hasPermission("Parkour.Admin.Testmode")) {
+					list.add("test");
+				}
+				if (sender.hasPermission("Parkour.Admin.Reset")) {
+					list.add("reset");
+				}
+				if (sender.hasPermission("Parkour.Admin.Delete")) {
+					list.add("delete");
+				}
+				if (sender.hasPermission("Parkour.Admin.Course") || isSelectedCourseOwner(sender)) {
+					list.add("checkpoint");
+					list.add("link");
+				}
+			}
+			
+			list.addAll(courseCmds);
+			
+		} else if (args.length == 2) {
+			if (courseCmds.contains(args[0])) {
+				for (String course : CourseInfo.getAllCourses()) {
+					list.add(course);
+				}
+			} else if (args[0].equalsIgnoreCase("list")) {
+				list.add("courses");
+				list.add("players");
+			} else if (args[0].equalsIgnoreCase("delete")) {
+				list.add("course");
+				list.add("checkpoint");
+				list.add("lobby");
+				list.add("kit");
+			} else if (args[0].equalsIgnoreCase("kit") || args[0].equalsIgnoreCase("listkit") || args[0].equalsIgnoreCase("validatekit")) {
+				for (String kit : Utils.getParkourKitList()) {
+					list.add(kit);
+				}
+			} else if (args[0].equalsIgnoreCase("reset")) {
+				list.add("course");
+				list.add("player");
+				list.add("leaderboard");
+				list.add("prize");
+			}
+		} else if (args.length == 3) {
+			if ((args[0].equalsIgnoreCase("reset") || args[0].equalsIgnoreCase("delete")) && args[1].equalsIgnoreCase("course")) {
+				for (String course : CourseInfo.getAllCourses()) {
+					list.add(course);
+				}
+			} else if ((args[0].equalsIgnoreCase("delete") && args[1].equalsIgnoreCase("kit")) || args[0].equalsIgnoreCase("linkkit")) {
+				for (String kit : Utils.getParkourKitList()) {
+					list.add(kit);
+				}
+			}
+		}
+		
+		for (String s : list) {
+			if (s.startsWith(args[args.length - 1])) {
+				auto.add(s);
+			}
+		}
+		
+		return auto.isEmpty() ? list : auto;
+	}
+	
+	private List<String> getCourseCmds(CommandSender sender) {
+		List<String> cmds = new ArrayList<String>();
+		List<String> adminCourseCmds = Arrays.asList("setcreator", "prize", "setmode", "setjoinitem", "setminlevel", 
+				"setmaxdeath", "rewardonce", "rewardlevel", "rewardleveladd", "rewardparkoins", "rewarddelay");
+		
+		cmds.add("join");
+		cmds.add("stats");
+		cmds.add("course");
+		cmds.add("select"); // so course owner can select own course
+		
+		if (sender.hasPermission("Parkour.Basic.*") || sender.hasPermission("Parkour.*")) {
+			cmds.add("challenge");
+			cmds.add("tp");
+			cmds.add("tpc");
+			cmds.add("leaderboard");
+		} else {
+			if (sender.hasPermission("Parkour.Basic.Challenge")) {
+				cmds.add("challenge");
+			}
+			if (sender.hasPermission("Parkour.Basic.TP")) {
+				cmds.add("tp");
+			}
+			if (sender.hasPermission("Parkour.Basic.TPC")) {
+				cmds.add("tpc");
+			}
+			if (sender.hasPermission("Parkour.Basic.Leaderboard")) {
+				cmds.add("leaderboard");
+			}
+		}
+		
+		if (sender.hasPermission("Parkour.Admin") || sender.hasPermission("Parkour.*")) {
+			cmds.addAll(adminCourseCmds);
+		}
+		if (sender.hasPermission("Parkour.Admin.*") || sender.hasPermission("Parkour.*") || sender.hasPermission("Parkour.Admin.Course") || isSelectedCourseOwner(sender)) {
+			cmds.add("edit");
+			cmds.add("linkkit");
+			cmds.add("setautostart");
+			cmds.add("finish");
+		} 
+		if (sender.hasPermission("Parkour.Admin.*") || sender.hasPermission("Parkour.Admin.Prize") || sender.hasPermission("Parkour.*")) {
+			cmds.add("prize");
+		}
+		return cmds;
+	}
+	
+	private boolean isSelectedCourseOwner(CommandSender sender) {
+		Player player = (Player) sender;
+		String courseName = PlayerInfo.getSelected(player);
+		if (courseName == null) {
+			return false;
+		}
+		return player.getName().equals(CourseInfo.getCreator(courseName));
+	}
+
+}

--- a/src/main/java/me/A5H73Y/Parkour/ParkourCommands.java
+++ b/src/main/java/me/A5H73Y/Parkour/ParkourCommands.java
@@ -102,7 +102,7 @@ class ParkourCommands implements CommandExecutor {
                         CourseMethods.setStart(player);
 
 					} else if (args[0].equalsIgnoreCase("setautostart")) {
-                        if (!Utils.hasPermission(player, "Parkour.Admin", "Prize"))
+                        if (!Utils.hasPermission(player, "Parkour.Admin", "Course"))
                             return false;
 
                         if (!Utils.validateArgs(player, args, 2))

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Utils.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Utils.java
@@ -14,7 +14,6 @@ import me.A5H73Y.Parkour.Player.PlayerMethods;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.data.type.Slab;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.SignChangeEvent;


### PR DESCRIPTION
Added auto tab completion class. Only Parkour commands that the player has permission to run are displayed.
Tab completion was tested on 1.8 -1.13.1. It works without any problems on older versions, but is not as fancy as on 1.13.1.

Changed permission required to run ```/pa setautostart``` from Parkour.Admin.Prize to Parkour.Admin.Course as this seems more logical.