### PR TITLE
#122 save and restore players health and food levels

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Other/Configurations.java
+++ b/src/main/java/me/A5H73Y/Parkour/Other/Configurations.java
@@ -422,10 +422,14 @@ public class Configurations {
         config.addDefault("OnJoin.EnforceFinished", true);
         config.addDefault("OnJoin.FillHealth", true);
         config.addDefault("OnJoin.Item.LastCheckpoint.Material", "ARROW");
+        config.addDefault("OnJoin.Item.LastCheckpoint.Slot", 0);
         config.addDefault("OnJoin.Item.HideAll.Material", "BONE");
+        config.addDefault("OnJoin.Item.HideAll.Slot", 1);
         config.addDefault("OnJoin.Item.HideAll.Global", true);
         config.addDefault("OnJoin.Item.Leave.Material", "SAPLING");
+        config.addDefault("OnJoin.Item.Leave.Slot", 2);
         config.addDefault("OnJoin.Item.Restart.Material", "STICK");
+        config.addDefault("OnJoin.Item.Restart.Slot", 3);
         config.addDefault("OnJoin.SetGamemode", 0);
         config.addDefault("OnJoin.TreatFirstCheckpointAsStart", false);
 

--- a/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
@@ -686,19 +686,19 @@ public class PlayerMethods {
         }
 
         if (Parkour.getSettings().getLastCheckpointTool() != null && !player.getInventory().contains(Parkour.getSettings().getLastCheckpointTool()))
-            player.getInventory().addItem(Utils.getItemStack(
+            player.getInventory().setItem(Parkour.getSettings().getLastCheckPointToolSlot(), Utils.getItemStack(
                     Parkour.getSettings().getLastCheckpointTool(), Utils.getTranslation("Other.Item_LastCheckpoint", false)));
 
         if (Parkour.getSettings().getHideallTool() != null && !player.getInventory().contains(Parkour.getSettings().getHideallTool()))
-            player.getInventory().addItem(Utils.getItemStack(
+            player.getInventory().setItem(Parkour.getSettings().getHideallToolSlot(), Utils.getItemStack(
                     Parkour.getSettings().getHideallTool(), Utils.getTranslation("Other.Item_HideAll", false)));
 
         if (Parkour.getSettings().getLeaveTool() != null && !player.getInventory().contains(Parkour.getSettings().getLeaveTool()))
-            player.getInventory().addItem(Utils.getItemStack(
+            player.getInventory().setItem(Parkour.getSettings().getLeaveToolSlot(), Utils.getItemStack(
                     Parkour.getSettings().getLeaveTool(), Utils.getTranslation("Other.Item_Leave", false)));
 
         if (Parkour.getSettings().getRestartTool() != null && !player.getInventory().contains(Parkour.getSettings().getRestartTool()))
-            player.getInventory().addItem(Utils.getItemStack(
+            player.getInventory().setItem(Parkour.getSettings().getRestartToolSlot(), Utils.getItemStack(
                     Parkour.getSettings().getRestartTool(), Utils.getTranslation("Other.Item_Restart", false)));
 
         if (CourseInfo.hasJoinItem(courseName)) {

--- a/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Player/PlayerMethods.java
@@ -95,6 +95,7 @@ public class PlayerMethods {
         teardownPlayerMode(player);
         removePlayer(player.getName());
         preparePlayer(player, Parkour.getPlugin().getConfig().getInt("OnFinish.SetGamemode"));
+        restoreHealth(player);
         loadInventory(player);
 
         if (Parkour.getPlugin().getConfig().getBoolean("OnDie.SetXPBarToDeathCount"))
@@ -213,6 +214,7 @@ public class PlayerMethods {
         final boolean teleportAway = Parkour.getPlugin().getConfig().getBoolean("OnFinish.TeleportAway");
 
         if (delay <= 0) {
+        	restoreHealth(player);
             loadInventory(player);
             givePrize(player, courseName);
             if (teleportAway) {
@@ -220,6 +222,7 @@ public class PlayerMethods {
             }
         } else {
             Bukkit.getScheduler().scheduleSyncDelayedTask(Parkour.getPlugin(), () -> {
+            	restoreHealth(player);
                 loadInventory(player);
                 givePrize(player, courseName);
                 if (teleportAway) {
@@ -671,6 +674,7 @@ public class PlayerMethods {
      */
     private static void prepareJoinPlayer(Player player, String courseName) {
         saveInventory(player);
+        saveHealth(player);
         preparePlayer(player, Parkour.getPlugin().getConfig().getInt("OnJoin.SetGamemode"));
 
         if (Parkour.getPlugin().getConfig().getBoolean("OnJoin.FillHealth"))
@@ -709,6 +713,17 @@ public class PlayerMethods {
         }
 
         player.updateInventory();
+    }
+    
+    /**
+     * Prepare the player for Parkour
+     * Store the player's health and hunger.
+     * @param player
+     */
+    private static void saveHealth(Player player) {
+    	Parkour.getParkourConfig().getInvData().set(player.getName() + ".Health", player.getHealth());
+    	Parkour.getParkourConfig().getInvData().set(player.getName() + ".Hunger", player.getFoodLevel());
+    	Parkour.getParkourConfig().saveInv();
     }
 
     /**
@@ -765,7 +780,7 @@ public class PlayerMethods {
      *
      * @param player
      */
-    public static void loadInventory(Player player) {
+    private static void loadInventory(Player player) {
         if (!Parkour.getPlugin().getConfig().getBoolean("Other.Parkour.InventoryManagement"))
             return;
 
@@ -799,6 +814,20 @@ public class PlayerMethods {
         player.updateInventory();
 
         Parkour.getParkourConfig().getInvData().set(player.getName(), null);
+        Parkour.getParkourConfig().saveInv();
+    }
+    /**
+     * Load the players original health.
+     * When they leave or finish a course, their hunger and exhaustion will be restored to them.
+     * Will delete the health from the config once loaded.
+     *
+     * @param player
+     */
+    private static void restoreHealth(Player player) {
+    	player.setHealth(Parkour.getParkourConfig().getInvData().getDouble(player.getName() + ".Health"));
+    	player.setFoodLevel(Parkour.getParkourConfig().getInvData().getInt(player.getName() + ".Hunger"));
+    	Parkour.getParkourConfig().getInvData().set(player.getName() + ".Health", null);
+    	Parkour.getParkourConfig().getInvData().set(player.getName() + ".Hunger", null);
         Parkour.getParkourConfig().saveInv();
     }
 

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Settings.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Settings.java
@@ -98,21 +98,37 @@ public class Settings {
 		Material lastCheckpointTool = Utils.lookupMaterial(getConfig().getString("OnJoin.Item.LastCheckpoint.Material"));
         return lastCheckpointTool == Material.AIR ? null : lastCheckpointTool;
 	}
+	
+	public int getLastCheckPointToolSlot() {
+		return Parkour.getPlugin().getConfig().getInt("OnJoin.Item.LastCheckpoint.Slot", 0);
+	}
 
 	public Material getHideallTool() {
 		Material hideallTool = Utils.lookupMaterial(getConfig().getString("OnJoin.Item.HideAll.Material"));
         return hideallTool == Material.AIR ? null : hideallTool;
+	}
+	
+	public int getHideallToolSlot() {
+		return Parkour.getPlugin().getConfig().getInt("OnJoin.Item.HideAll.Slot", 1);
 	}
 
 	public Material getLeaveTool() {
 		Material leaveTool = Utils.lookupMaterial(getConfig().getString("OnJoin.Item.Leave.Material"));
         return leaveTool == Material.AIR ? null : leaveTool;
 	}
+	
+	public int getLeaveToolSlot() {
+		return Parkour.getPlugin().getConfig().getInt("OnJoin.Item.Leave.Slot", 2);
+	}
 
     public Material getRestartTool() {
 		Material restartTool = Utils.lookupMaterial(getConfig().getString("OnJoin.Item.Restart.Material"));
         return restartTool == Material.AIR ? null : restartTool;
     }
+    
+    public int getRestartToolSlot() {
+		return Parkour.getPlugin().getConfig().getInt("OnJoin.Item.Restart.Slot", 3);
+	}
 
     public Material getAutoStartMaterial() {
 	    return Utils.lookupMaterial(getConfig().getString("AutoStart.Material"));


### PR DESCRIPTION
Fixes #122 by storing the players health with the inventory data in inventory.yml. 
Players leave a Parkour course with the same levels that they joined with.