### PR TITLE
allow leaderboard signs to function if course name begins with an uppercase letter

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Utilities/DatabaseMethods.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/DatabaseMethods.java
@@ -344,7 +344,7 @@ public class DatabaseMethods {
 
         List<TimeObject> times = new ArrayList<>();
         try {
-            int courseId = getCourseId(courseName);
+            int courseId = getCourseId(courseName.toLowerCase());
             if (courseId == 0)
                 return times;
 
@@ -372,7 +372,7 @@ public class DatabaseMethods {
 
         List<TimeObject> times = new ArrayList<>();
         try {
-            int courseId = getCourseId(courseName);
+            int courseId = getCourseId(courseName.toLowerCase());
             if (courseId == 0)
                 return times;
 


### PR DESCRIPTION
Parkour signs allow course names to begin with an uppercase letter, although the course names are stored internally in lowercase.
This change allows Leaderboard signs to function in the same way as Join, Stats, Checkpoint signs etc.,  in that if the course name is specified with an uppercase letter on the sign, the database search for course ID is done in lowercase.

It also allows the _/pa leaderboard <coursename>_ command to be used with an uppercase letter in the same way as _/pa stats <coursename>_ currently does,
e.g. 
/pa stats Parkour1
/pa leaderboard Parkour1

