### PR TITLE
Add option to prevent player collisions

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Managers/ScoreboardManager.java
+++ b/src/main/java/me/A5H73Y/Parkour/Managers/ScoreboardManager.java
@@ -70,9 +70,9 @@ public class ScoreboardManager {
 
         Scoreboard board = setupScoreboard(player);
 
-        if (Parkour.getSettings().isPreventPlayerCollisions()) {
+        if (Parkour.getSettings().isPreventPlayerCollisions() && !Bukkit.getBukkitVersion().contains("1.8")) {
             Team team = board.registerNewTeam("parkour");
-            team.setOption(Team.Option.COLLISION_RULE, Team.OptionStatus.NEVER);
+            team.setOption(Team.Option.COLLISION_RULE, Team.OptionStatus.NEVER); 
             team.addEntry(player.getName());
         }
 

--- a/src/main/java/me/A5H73Y/Parkour/Managers/ScoreboardManager.java
+++ b/src/main/java/me/A5H73Y/Parkour/Managers/ScoreboardManager.java
@@ -172,7 +172,7 @@ public class ScoreboardManager {
     private String cropAndColour(String text) {
         text = Utils.colour(text);
         if (Utils.getMinorServerVersion() < 13) {
-            text = text.substring(0, Math.min(15, text.length() - 1));
+            text = text.substring(0, Math.min(15, text.length()));
         }
         return text;
     }

--- a/src/main/java/me/A5H73Y/Parkour/Managers/ScoreboardManager.java
+++ b/src/main/java/me/A5H73Y/Parkour/Managers/ScoreboardManager.java
@@ -70,7 +70,7 @@ public class ScoreboardManager {
 
         Scoreboard board = setupScoreboard(player);
 
-        if (Parkour.getSettings().isPreventPlayerCollisions() && !Bukkit.getBukkitVersion().contains("1.8")) {
+        if (Parkour.getSettings().isPreventPlayerCollisions() && Utils.getMinorServerVersion() > 8) {
             Team team = board.registerNewTeam("parkour");
             team.setOption(Team.Option.COLLISION_RULE, Team.OptionStatus.NEVER); 
             team.addEntry(player.getName());

--- a/src/main/java/me/A5H73Y/Parkour/Managers/ScoreboardManager.java
+++ b/src/main/java/me/A5H73Y/Parkour/Managers/ScoreboardManager.java
@@ -69,6 +69,13 @@ public class ScoreboardManager {
             return;
 
         Scoreboard board = setupScoreboard(player);
+
+        if (Parkour.getSettings().isPreventPlayerCollisions()) {
+            Team team = board.registerNewTeam("parkour");
+            team.setOption(Team.Option.COLLISION_RULE, Team.OptionStatus.NEVER);
+            team.addEntry(player.getName());
+        }
+
         player.setScoreboard(board);
     }
 

--- a/src/main/java/me/A5H73Y/Parkour/Other/Configurations.java
+++ b/src/main/java/me/A5H73Y/Parkour/Other/Configurations.java
@@ -466,6 +466,7 @@ public class Configurations {
         config.addDefault("OnCourse.PreventAttackingEntities", false);
         config.addDefault("OnCourse.PreventJoiningDifferentCourse", false);
         config.addDefault("OnCourse.PreventAllPotionEffects", false);
+        config.addDefault("OnCourse.PreventPlayerCollisions", false);
         config.addDefault("OnCourse.SneakToInteractItems", true);
         config.addDefault("OnCourse.UseParkourKit", true);
         config.addDefault("OnCourse.Trails.Enabled", false);

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Settings.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Settings.java
@@ -77,6 +77,9 @@ public class Settings {
 		return getConfig().getBoolean("OnCourse.PreventAttackingEntities");
 	}
 
+	public boolean isPreventPlayerCollisions() {
+		return getConfig().getBoolean("OnCourse.PreventPlayerCollisions");
+	}
 	public boolean isDisplayMilliseconds() {
 		return getConfig().getBoolean("Other.Display.ShowMilliseconds");
 	}


### PR DESCRIPTION
Player collisions are done client-side and controlled using scoreboards - so whenever a player joins a course, he/she also joins a team. ~~Everyone is basically in the same team.~~ Each team has COLLISION_RULE set to NEVER so its players don't collide with other  players.

Scoreboard has to be enabled in the config.  
On MC1.8 player collisions didn't exist so its not relevant, but the option needs to be disabled to prevent an exception.