### PR TITLE
some gui adjustments

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Commands/ParkourCommands.java
+++ b/src/main/java/me/A5H73Y/Parkour/Commands/ParkourCommands.java
@@ -528,7 +528,7 @@ public class ParkourCommands implements CommandExecutor {
 
             //TODO move me up further, and document me everywhere
         } else if (args[0].equalsIgnoreCase("joinall")) {
-            if (Utils.hasPermission(player, "Parkour.GUI", "JoinAll")) {
+            if (!Utils.hasPermission(player, "Parkour.GUI", "JoinAll")) {
                 return false;
             }
 

--- a/src/main/java/me/A5H73Y/Parkour/GUI/InventoryBuilder.java
+++ b/src/main/java/me/A5H73Y/Parkour/GUI/InventoryBuilder.java
@@ -29,7 +29,7 @@ public abstract class InventoryBuilder {
 
         List<String> items = getAllItems();
 
-        int listStartIndex = (page * 9) - 9;
+        int listStartIndex = (page * (inventorySize - 9)) - (inventorySize - 9);
         int remainingItems = Math.min(items.size() - listStartIndex, inventorySize - 9);
         int listEndIndex = listStartIndex + remainingItems;
 

--- a/src/main/java/me/A5H73Y/Parkour/GUI/ParkourCoursesInventory.java
+++ b/src/main/java/me/A5H73Y/Parkour/GUI/ParkourCoursesInventory.java
@@ -2,6 +2,7 @@ package me.A5H73Y.Parkour.GUI;
 
 import me.A5H73Y.Parkour.Course.CourseInfo;
 import me.A5H73Y.Parkour.Utilities.Utils;
+import me.A5H73Y.Parkour.Parkour;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -27,9 +28,7 @@ public class ParkourCoursesInventory extends InventoryBuilder {
     public Inventory buildInventory(Player player, int page) {
         Inventory inventory = super.buildInventory(player, page);
 
-        Material material = Material.valueOf(
-                Utils.getTranslation("ParkourGUI.AllCourses.Material", false)
-        );
+        Material material = Parkour.getSettings().getGUIMaterial();
 
         for (int i = 0; i < getFilteredItems().size(); i++) {
             String course = getFilteredItems().get(i);

--- a/src/main/java/me/A5H73Y/Parkour/Listeners/PlayerInventoryListener.java
+++ b/src/main/java/me/A5H73Y/Parkour/Listeners/PlayerInventoryListener.java
@@ -1,5 +1,6 @@
 package me.A5H73Y.Parkour.Listeners;
 
+import me.A5H73Y.Parkour.Parkour;
 import me.A5H73Y.Parkour.GUI.InventoryBuilder;
 import me.A5H73Y.Parkour.GUI.ParkourCoursesInventory;
 import me.A5H73Y.Parkour.Utilities.Utils;
@@ -42,9 +43,7 @@ public class PlayerInventoryListener implements Listener {
         }
 
         List<String> metadata = event.getCurrentItem().getItemMeta().getLore();
-        Material itemMaterial = Material.getMaterial(
-                Utils.getTranslation("ParkourGUI.AllCourses.Material", false)
-        );
+        Material itemMaterial = Parkour.getSettings().getGUIMaterial();
 
         if (clickedItem.equals(itemMaterial)) {
             String command = metadata.get(0);

--- a/src/main/java/me/A5H73Y/Parkour/Other/Configurations.java
+++ b/src/main/java/me/A5H73Y/Parkour/Other/Configurations.java
@@ -397,7 +397,6 @@ public class Configurations {
             stringData.addDefault("ParkourGUI.AllCourses.Title", "Courses - Page %PAGE%");
             stringData.addDefault("ParkourGUI.AllCourses.Description", "&fJoin &b%COURSE%");
             stringData.addDefault("ParkourGUI.AllCourses.Command", "pa join %COURSE%");
-            stringData.addDefault("ParkourGUI.AllCourses.Material", "BOOK");
 
             stringData.addDefault("Economy.Insufficient", "You require at least &b%AMOUNT% &fbefore joining &b%COURSE%");
             stringData.addDefault("Economy.Fee", "&b%AMOUNT% &fhas been deducted from your balance for joining &b%COURSE%");
@@ -533,6 +532,7 @@ public class Configurations {
 
         config.addDefault("ParkourGUI.Enabled", false);
         config.addDefault("ParkourGUI.Rows", 2);
+        config.addDefault("ParkourGUI.Material", "BOOK");
 
         config.addDefault("Other.CheckForUpdates", true);
         config.addDefault("Other.BountifulAPI.Enabled", true);

--- a/src/main/java/me/A5H73Y/Parkour/Player/PlayerInfo.java
+++ b/src/main/java/me/A5H73Y/Parkour/Player/PlayerInfo.java
@@ -8,7 +8,6 @@ import me.A5H73Y.Parkour.Utilities.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 
 import java.util.List;

--- a/src/main/java/me/A5H73Y/Parkour/Utilities/Settings.java
+++ b/src/main/java/me/A5H73Y/Parkour/Utilities/Settings.java
@@ -138,6 +138,11 @@ public class Settings {
 		return Utils.lookupMaterial(getConfig().getString("AutoStart.Material"));
 	}
 
+	public Material getGUIMaterial() {
+		Material guiMaterial = Utils.lookupMaterial(getConfig().getString("ParkourGUI.Material"));
+		return guiMaterial == null ? Material.BOOK : guiMaterial;
+	}
+
 	/* Strings */
 
 	public String getCheckpointMaterial() {


### PR DESCRIPTION
I was trying out the `/pa joinall` gui and made some provisional changes:
1) the permission to run it is inverted (which we discussed)
2) the paging was kind of out, so with rows=2 for example, courses 1-18 were on page1, courses 9-27 were on page 2, etc. 
3) I moved the GUI material to _config.yml_ rather than _strings.yml_. Apologies if you wanted it there for a reason but I thought I'd move it as I was testing stuff :-)