### PR TITLE
players can't stand on a slab placed on a death block

### DIFF
--- a/src/main/java/me/A5H73Y/Parkour/Listeners/PlayerMoveListener.java
+++ b/src/main/java/me/A5H73Y/Parkour/Listeners/PlayerMoveListener.java
@@ -108,6 +108,10 @@ public class PlayerMoveListener implements Listener {
         }
 
         Material belowMaterial = player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType();
+        // if player is on half-block or jumping, get actual location.
+        if (player.getLocation().getBlock().getType() != Material.AIR || !player.isOnGround()) {
+            belowMaterial = player.getLocation().getBlock().getType();
+        }
         ParkourKit kit = session.getCourse().getParkourKit();
 
         if (belowMaterial.equals(Material.SPONGE)) {


### PR DESCRIPTION
This is with reference to #147 Liquid detection is too aggressive.

Currently players cannot stand on a slab or any other 'half-block' placed directly on top of a designated death-block, as the listener checks the _block under_ the player's current location.

So, for example, if WATER is a death block, a player can't step onto a LILY_PAD, or if STONE_BRICK is a death-block a player cannot step onto an OAK_SLAB placed directly on top of a STONE_BRICK block (because the block under their location is a death-block).

When the player is standing on any sort of 'half-block' the listener should probably check the player's _actual_ location rather than the block under it.

Also, using the LILY_PAD example, once on the LILY_PAD the player then has to jump _through_ the adjacent AIR block to leave it. Currently that would be impossible if the block below the AIR block is WATER.

=====

I guess we don't really want to add unnecessary checks to PlayerMoveEvent, so this could just as easily be "rules":
Don't use slabs on top of, or next to, death blocks;
Use the DieInLiquid option for WATER/LILY_PADS.
