### PR TITLE
scoreboard updates including checkpoints

### DIFF
--- a/src/main/java/io/github/a5h73y/config/impl/DefaultFile.java
+++ b/src/main/java/io/github/a5h73y/config/impl/DefaultFile.java
@@ -108,6 +108,7 @@ public class DefaultFile extends ParkourConfiguration {
 		this.addDefault("Scoreboard.Display.BestTimeByMe", true);
 		this.addDefault("Scoreboard.Display.CurrentTime", true);
 		this.addDefault("Scoreboard.Display.CurrentDeaths", true);
+		this.addDefault("Scoreboard.Display.Checkpoints", true);
 
 		this.addDefault("ParkourGUI.Enabled", false);
 		this.addDefault("ParkourGUI.Rows", 2);

--- a/src/main/java/io/github/a5h73y/config/impl/StringsFile.java
+++ b/src/main/java/io/github/a5h73y/config/impl/StringsFile.java
@@ -124,6 +124,7 @@ public class StringsFile extends ParkourConfiguration {
 		this.addDefault("Scoreboard.MyBestTimeTitle", "My Best Time:");
 		this.addDefault("Scoreboard.CurrentTimeTitle", "Current Time:");
 		this.addDefault("Scoreboard.CurrentDeathsTitle", "Current Deaths:");
+		this.addDefault("Scoreboard.CheckpointsTitle", "Checkpoints:");
 
 		this.addDefault("ParkourGUI.NextPage", "&bNext page &f>");
 		this.addDefault("ParkourGUI.PreviousPage", "< &bPrevious page");

--- a/src/main/java/io/github/a5h73y/manager/ScoreboardManager.java
+++ b/src/main/java/io/github/a5h73y/manager/ScoreboardManager.java
@@ -9,6 +9,7 @@ import io.github.a5h73y.config.ParkourConfiguration;
 import io.github.a5h73y.course.CourseMethods;
 import io.github.a5h73y.enums.ConfigType;
 import io.github.a5h73y.other.TimeObject;
+import io.github.a5h73y.player.PlayerMethods;
 import io.github.a5h73y.utilities.DatabaseMethods;
 import io.github.a5h73y.utilities.Utils;
 import org.bukkit.Bukkit;
@@ -30,6 +31,7 @@ public class ScoreboardManager {
     private final String BEST_TIME_EVER_ME = ChatColor.DARK_AQUA.toString();
     private final String CURRENT_TIME = ChatColor.DARK_BLUE.toString();
     private final String CURRENT_DEATHS = ChatColor.DARK_GREEN.toString();
+    private final String CHECKPOINTS = ChatColor.DARK_RED.toString();
 
     private final String titleFormat;
     private final String textFormat;
@@ -55,6 +57,7 @@ public class ScoreboardManager {
         configKey.put(CURRENT_TIME, defaultConfig.getBoolean("Scoreboard.Display.CurrentTime")
                 && defaultConfig.getBoolean("OnCourse.DisplayLiveTime"));
         configKey.put(CURRENT_DEATHS, defaultConfig.getBoolean("Scoreboard.Display.CurrentDeaths"));
+        configKey.put(CHECKPOINTS, defaultConfig.getBoolean("Scoreboard.Display.Checkpoints"));
 
         translationKey.put("mainHeading", stringsConfig.getString("Scoreboard.MainHeading"));
         translationKey.put("notCompleted", stringsConfig.getString("Scoreboard.NotCompleted"));
@@ -64,6 +67,7 @@ public class ScoreboardManager {
         translationKey.put(BEST_TIME_EVER_ME, stringsConfig.getString("Scoreboard.MyBestTimeTitle"));
         translationKey.put(CURRENT_TIME, stringsConfig.getString("Scoreboard.CurrentTimeTitle"));
         translationKey.put(CURRENT_DEATHS, stringsConfig.getString("Scoreboard.CurrentDeathsTitle"));
+        translationKey.put(CHECKPOINTS, stringsConfig.getString("Scoreboard.CheckpointsTitle"));
 
         this.numberOfRowsNeeded = calculateNumberOfRowsNeeded();
     }
@@ -91,7 +95,7 @@ public class ScoreboardManager {
     public void updateScoreboardTimer(Player player, String liveTime) {
         Scoreboard board = player.getScoreboard();
 
-        if (board == null || !configKey.get(CURRENT_TIME) || board.getTeam(CURRENT_TIME) == null) {
+        if (board == null || !configKey.get(CURRENT_TIME)) {
             return;
         }
 
@@ -106,6 +110,16 @@ public class ScoreboardManager {
         }
 
         board.getTeam(CURRENT_DEATHS).setPrefix(convertText(deaths));
+    }
+
+    public void updateScoreboardCheckpoints(Player player, String checkpoints) {
+        Scoreboard board = player.getScoreboard();
+
+        if (board == null || !configKey.get(CHECKPOINTS)) {
+            return;
+        }
+
+        board.getTeam(CHECKPOINTS).setPrefix(convertText(checkpoints));
     }
 
     private Scoreboard setupScoreboard(Player player) {
@@ -125,6 +139,7 @@ public class ScoreboardManager {
         addBestTimeEverMe(playerScoreboard);
         addCurrentTime(playerScoreboard);
         addCurrentDeaths(playerScoreboard);
+        addCheckpoints(playerScoreboard);
 
         return board;
     }
@@ -181,6 +196,15 @@ public class ScoreboardManager {
         }
 
         print(playerBoard, "0", CURRENT_DEATHS);
+    }
+
+    private void addCheckpoints(PlayerScoreboard playerBoard) {
+        if (!configKey.get(CHECKPOINTS)) {
+            return;
+        }
+
+        int total_chkpts = PlayerMethods.getParkourSession(playerBoard.playerName).getCourse().getCheckpoints();
+        print(playerBoard, "0 / " + String.valueOf(total_chkpts), CHECKPOINTS);
     }
 
     private void print(PlayerScoreboard playerBoard, String result, String scoreboardKey) {
@@ -240,6 +264,9 @@ public class ScoreboardManager {
             rowsNeeded += 2;
         }
         if (configKey.get(CURRENT_DEATHS)) {
+            rowsNeeded += 2;
+        }
+        if (configKey.get(CHECKPOINTS)) {
             rowsNeeded += 2;
         }
         return rowsNeeded;

--- a/src/main/java/io/github/a5h73y/player/ParkourSession.java
+++ b/src/main/java/io/github/a5h73y/player/ParkourSession.java
@@ -82,9 +82,7 @@ public class ParkourSession implements Serializable {
                     }
                 }
 
-                boolean useScoreboard = Parkour.getInstance().getConfig().getBoolean("Scoreboard.Display.CurrentTime");
-
-                if (Parkour.getScoreboardManager().isEnabled() && useScoreboard) {
+                if (Parkour.getScoreboardManager().isEnabled()) {
                     Parkour.getScoreboardManager().updateScoreboardTimer(player, liveTime);
 
                 } else if (Static.getBountifulAPI()) {

--- a/src/main/java/io/github/a5h73y/player/PlayerMethods.java
+++ b/src/main/java/io/github/a5h73y/player/PlayerMethods.java
@@ -330,13 +330,13 @@ public class PlayerMethods {
         ParkourSession session = getParkourSession(player.getName());
         session.restartSession();
 
+        if (Parkour.getSettings().isFirstCheckAsStart()) {
+            session.increaseCheckpoint();
+        }
+
         if (Parkour.getScoreboardManager().isEnabled()) {
         	    Parkour.getScoreboardManager().updateScoreboardDeaths(player, String.valueOf(session.getDeaths()));
         	    Parkour.getScoreboardManager().updateScoreboardCheckpoints(player, String.valueOf(session.getCheckpoint() + " / " + session.getCourse().getCheckpoints()));
-        }
-
-        if (Parkour.getSettings().isFirstCheckAsStart()) {
-            session.increaseCheckpoint();
         }
 
         player.sendMessage(Utils.getTranslation("Parkour.Restarting"));

--- a/src/main/java/io/github/a5h73y/player/PlayerMethods.java
+++ b/src/main/java/io/github/a5h73y/player/PlayerMethods.java
@@ -152,7 +152,9 @@ public class PlayerMethods {
         ParkourSession session = getParkourSession(player.getName());
         session.increaseDeath();
 
-        Parkour.getScoreboardManager().updateScoreboardDeaths(player, String.valueOf(session.getDeaths()));
+        if (Parkour.getScoreboardManager().isEnabled()) {
+            Parkour.getScoreboardManager().updateScoreboardDeaths(player, String.valueOf(session.getDeaths()));
+        }
 
         if (session.getCourse().hasMaxDeaths()) {
             if (session.getCourse().getMaxDeaths() > session.getDeaths()) {
@@ -328,7 +330,10 @@ public class PlayerMethods {
         ParkourSession session = getParkourSession(player.getName());
         session.restartSession();
 
-        Parkour.getScoreboardManager().updateScoreboardDeaths(player, String.valueOf(session.getDeaths()));
+        if (Parkour.getScoreboardManager().isEnabled()) {
+        	    Parkour.getScoreboardManager().updateScoreboardDeaths(player, String.valueOf(session.getDeaths()));
+        	    Parkour.getScoreboardManager().updateScoreboardCheckpoints(player, String.valueOf(session.getCheckpoint() + " / " + session.getCourse().getCheckpoints()));
+        }
 
         if (Parkour.getSettings().isFirstCheckAsStart()) {
             session.increaseCheckpoint();
@@ -1063,6 +1068,10 @@ public class PlayerMethods {
      */
     public static void increaseCheckpoint(ParkourSession session, Player player) {
         session.increaseCheckpoint();
+
+        if (Parkour.getScoreboardManager().isEnabled()) {
+            Parkour.getScoreboardManager().updateScoreboardCheckpoints(player, String.valueOf(session.getCheckpoint() + " / " + session.getCourse().getCheckpoints()));
+        }
 
         boolean showTitle = Parkour.getInstance().getConfig().getBoolean("DisplayTitle.Checkpoint");
         if (session.getCourse().getCheckpoints() == session.getCheckpoint()) {


### PR DESCRIPTION
Fixes #152 and fixes #158 

I've tested as many different combinations of config options as I can. The npe problems appeared to be from having the scoreboard disabled, the "if (board ==null)" always being false in ScoreboardManager, and restarting the course timer with the restart item. The checks are now consistent for timer, deaths and checkpoints.
The checkpoint count is updated to 1 in the scoreboard if TreatFirstCheckpointAsStart is true. 