### PR TITLE
challenge is forfeited if player quits or leaves course

### DIFF
--- a/src/main/java/io/github/a5h73y/config/impl/StringsFile.java
+++ b/src/main/java/io/github/a5h73y/config/impl/StringsFile.java
@@ -69,6 +69,8 @@ public class StringsFile extends ParkourConfiguration {
 		this.addDefault("Parkour.Challenge.Send", "You have challenged &b%PLAYER% &fto course &b%COURSE%");
 		this.addDefault("Parkour.Challenge.Wager", " &fwith a wager of &b%AMOUNT%");
 		this.addDefault("Parkour.Challenge.Terminated", "&b%PLAYER% &fhas terminated the challenge!");
+		this.addDefault("Parkour.Challenge.Forfeited", "&b%PLAYER% &fhas forfeited the challenge. Complete the course to win!");
+		this.addDefault("Parkour.Challenge.Quit", "You have forfeited the challenge. &b%PLAYER% &fmust complete the course to win!");
 		this.addDefault("Parkour.Challenge.Winner", "Congratulations! You beat &b%PLAYER% &fat &b%COURSE%!");
 		this.addDefault("Parkour.Challenge.Loser", "&b%PLAYER% &fhas completed &b%COURSE% &fbefore you!");
 

--- a/src/main/java/io/github/a5h73y/course/CourseInfo.java
+++ b/src/main/java/io/github/a5h73y/course/CourseInfo.java
@@ -540,7 +540,6 @@ public class CourseInfo {
         int minLevel = config.getInt(courseName + ".MinimumLevel");
         int rewardLevel = config.getInt(courseName + ".Level");
         int rewardLevelAdd = config.getInt(courseName + ".LevelAdd");
-        int XP = config.getInt(courseName + ".XP");
         int parkoins = config.getInt(courseName + ".Parkoins");
 
         String linkedLobby = config.getString(courseName + ".LinkedLobby");
@@ -578,10 +577,6 @@ public class CourseInfo {
 
         if (linkedCourse != null && linkedCourse.length() > 0) {
             player.sendMessage("Linked Course: " + aqua + linkedCourse);
-        }
-
-        if (XP > 0) {
-            player.sendMessage("XP Reward: " + aqua + XP);
         }
 
         if (parkoins > 0) {

--- a/src/main/java/io/github/a5h73y/course/CourseInfo.java
+++ b/src/main/java/io/github/a5h73y/course/CourseInfo.java
@@ -621,6 +621,16 @@ public class CourseInfo {
             player.sendMessage("Liked: " + aqua + likePercent + "%");
         }
 
+        if (hasMaterialPrize(courseName) && getMaterialPrizeAmount(courseName) > 0) {
+            player.sendMessage("Material Prize: " + aqua + getMaterialPrize(courseName) + " x " + getMaterialPrizeAmount(courseName));
+        }
+        if (hasCommandPrize(courseName)) {
+            player.sendMessage("Command Prize: " + aqua + getCommandsPrize(courseName));
+        }
+        if (getXPPrize(courseName) > 0) {
+            player.sendMessage("XP Prize: " + aqua + getXPPrize(courseName));
+        }
+
         if (hasRewardDelay(courseName) && Parkour.getSettings().isDisplayPrizeCooldown()) {
             player.sendMessage("Reward Cooldown (days): " + aqua + getRewardDelay(courseName));
             if (!Utils.hasPrizeCooldownDurationPassed(player, courseName, false)) {

--- a/src/main/java/io/github/a5h73y/course/CourseMethods.java
+++ b/src/main/java/io/github/a5h73y/course/CourseMethods.java
@@ -146,7 +146,6 @@ public class CourseMethods {
         courseConfig.set(name + ".Creator", player.getName());
         courseConfig.set(name + ".Views", 0);
         courseConfig.set(name + ".Completed", 0);
-        courseConfig.set(name + ".XP", 0);
         courseConfig.set(name + ".Points", 0);
         courseConfig.set(name + ".World", location.getWorld().getName());
         courseConfig.set(name + ".0.X", location.getBlockX() + 0.5);
@@ -818,7 +817,6 @@ public class CourseMethods {
         courseConfig.set(courseName + ".Views", 0);
         courseConfig.set(courseName + ".Completed", 0);
         courseConfig.set(courseName + ".Finished", false);
-        courseConfig.set(courseName + ".XP", null);
         courseConfig.set(courseName + ".Level", null);
         courseConfig.set(courseName + ".MinimumLevel", null);
         courseConfig.set(courseName + ".LevelAdd", null);

--- a/src/main/java/io/github/a5h73y/manager/ChallengeManager.java
+++ b/src/main/java/io/github/a5h73y/manager/ChallengeManager.java
@@ -230,7 +230,7 @@ public class ChallengeManager {
         private final String courseName;
 
         private final Double wager;
-		private boolean forfeited;
+        private boolean forfeited;
 
         /**
          * Challenge player

--- a/src/main/java/io/github/a5h73y/manager/ChallengeManager.java
+++ b/src/main/java/io/github/a5h73y/manager/ChallengeManager.java
@@ -78,7 +78,10 @@ public class ChallengeManager {
 
     /**
      * Terminate a Challenge.
-     * In the event that someone leaves the course / server
+     * In the event that someone leaves the course / server or
+     * exceeds the maximum deaths set for the course. The first player to
+     * leave forfeits the challenge. The remaining player must complete
+     * the course to win the challenge.
      *
      * @param leaver
      */
@@ -87,9 +90,20 @@ public class ChallengeManager {
 
         if (challenge != null) {
             Player opponent = calculateOpponent(leaver.getName(), challenge);
+
+            if (!challenge.isForfeited()) {
+                challenge.forfeited = true;
+                leaver.sendMessage(Utils.getTranslation("Parkour.Challenge.Quit")
+                        .replace("%PLAYER%", opponent.getName()));
+                opponent.sendMessage(Utils.getTranslation("Parkour.Challenge.Forfeited")
+                        .replace("%PLAYER%", leaver.getName()));
+                return;
+            }
+
             String terminateMessage = Utils.getTranslation("Parkour.Challenge.Terminated")
                     .replace("%PLAYER%", leaver.getName());
             leaver.sendMessage(terminateMessage);
+
             if (opponent != null) {
                 opponent.sendMessage(terminateMessage);
             }
@@ -124,7 +138,9 @@ public class ChallengeManager {
                 Parkour.getEconomy().withdrawPlayer(opponent, challenge.wager);
             }
 
-            PlayerMethods.playerLeave(opponent);
+            if (!challenge.isForfeited()) {
+                PlayerMethods.playerLeave(opponent);
+            }
         }
     }
 
@@ -214,10 +230,11 @@ public class ChallengeManager {
         private final String courseName;
 
         private final Double wager;
+		private boolean forfeited;
 
         /**
          * Challenge player
-         * Created to manage who started the challenge, who's the receiver and which on course.
+         * Created to manage who started the challenge, who's the receiver and on which course.
          *
          * @param senderPlayer
          * @param receiverPlayer
@@ -228,6 +245,7 @@ public class ChallengeManager {
             this.receiverPlayer = receiverPlayer;
             this.courseName = courseName;
             this.wager = wager;
+            this.forfeited = false;
         }
 
         public String getSenderPlayer() {
@@ -244,6 +262,10 @@ public class ChallengeManager {
 
         public Double getWager() {
             return wager;
+        }
+
+        public boolean isForfeited() {
+            return forfeited;
         }
 
     }


### PR DESCRIPTION
fixes #164 
fixes issue with player exceeding max_deaths and challenge being terminated with no winner.
also, now behaves as per wiki, " Forfeiting (leaving the course or server) will be treated as a loss and the wager will be deducted.." instead of terminating the challenge.

The remaining player must still complete the course to win the challenge/wager.