### PR TITLE
fix ssl errors for people using mysql 8

### DIFF
--- a/src/main/java/com/huskehhh/mysql/mysql/MySQL.java
+++ b/src/main/java/com/huskehhh/mysql/mysql/MySQL.java
@@ -46,7 +46,7 @@ public class MySQL extends Database {
 
         String connectionURL = "jdbc:mysql://" + this.hostname + ":" + this.port;
         if (database != null) {
-            connectionURL += "/" + this.database;
+            connectionURL += "/" + this.database + "?useSSL=false";
         }
 
         try {


### PR DESCRIPTION
If you're using MySQL 8 rather than a subversion of MySQL 5, it expects connections to make use of SSL by default, so the console gets spammed with a message on every MySQL connection this plugin makes.

The added string fixes the issue by telling the connection to occur without SSL.