### PR TITLE
use spigot api for actionbar messages

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/manager/ScoreboardManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/manager/ScoreboardManager.java
@@ -53,8 +53,7 @@ public class ScoreboardManager {
         configKey.put(BEST_TIME_EVER, defaultConfig.getBoolean("Scoreboard.Display.BestTimeEver"));
         configKey.put(BEST_TIME_EVER_NAME, defaultConfig.getBoolean("Scoreboard.Display.BestTimeEverName"));
         configKey.put(BEST_TIME_EVER_ME, defaultConfig.getBoolean("Scoreboard.Display.BestTimeByMe"));
-        configKey.put(CURRENT_TIME, defaultConfig.getBoolean("Scoreboard.Display.CurrentTime")
-                && defaultConfig.getBoolean("OnCourse.DisplayLiveTime"));
+        configKey.put(CURRENT_TIME, defaultConfig.getBoolean("Scoreboard.Display.CurrentTime"));
         configKey.put(CURRENT_DEATHS, defaultConfig.getBoolean("Scoreboard.Display.CurrentDeaths"));
         configKey.put(CHECKPOINTS, defaultConfig.getBoolean("Scoreboard.Display.Checkpoints"));
 

--- a/src/main/java/io/github/a5h73y/parkour/player/ParkourSession.java
+++ b/src/main/java/io/github/a5h73y/parkour/player/ParkourSession.java
@@ -9,7 +9,6 @@ import io.github.a5h73y.parkour.course.CourseMethods;
 import io.github.a5h73y.parkour.enums.ParkourMode;
 import io.github.a5h73y.parkour.manager.QuietModeManager;
 import io.github.a5h73y.parkour.utilities.Utils;
-import io.github.a5h73y.parkour.utilities.Static;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Sound;
@@ -53,9 +52,16 @@ public class ParkourSession implements Serializable {
         this.mode = CourseMethods.getCourseMode(course.getName());
     }
 
+    /**
+     * Start the visual timer either on the ActionBar if DisplayLiveTime is true, or in the scoreboard
+     * if the scoreboard is enabled and the display current time option is true.
+     */
     public void startVisualTimer(final Player player) {
-        if (!Parkour.getInstance().getConfig().getBoolean("OnCourse.DisplayLiveTime")
-                || QuietModeManager.getInstance().isInQuietMode(player.getName())) {
+        if (QuietModeManager.getInstance().isInQuietMode(player.getName()) ) {
+            return;
+        }
+        if (!Parkour.getInstance().getConfig().getBoolean("OnCourse.DisplayLiveTime") && (!Parkour.getScoreboardManager().isEnabled()
+                    || !Parkour.getInstance().getConfig().getBoolean("Scoreboard.Display.CurrentTime"))) {
             return;
         }
 
@@ -88,7 +94,7 @@ public class ParkourSession implements Serializable {
                     Parkour.getScoreboardManager().updateScoreboardTimer(player, liveTime);
                 }
 
-                if (Static.getBountifulAPI()) {
+                if (Parkour.getInstance().getConfig().getBoolean("OnCourse.DisplayLiveTime")) {
                     Utils.sendActionBar(player, liveTime, true);
                 }
 

--- a/src/main/java/io/github/a5h73y/parkour/utilities/Utils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utilities/Utils.java
@@ -28,6 +28,9 @@ import io.github.a5h73y.parkour.database.TimeEntry;
 import io.github.a5h73y.parkour.other.Validation;
 import io.github.a5h73y.parkour.player.PlayerInfo;
 import io.github.a5h73y.parkour.player.PlayerMethods;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
@@ -507,8 +510,8 @@ public final class Utils {
             return;
         }
 
-        if (Static.getBountifulAPI() && attemptTitle) {
-            BountifulAPI.sendActionBar(player, title);
+        if (attemptTitle) {
+            player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(title));
         } else {
             player.sendMessage(Static.getParkourString() + title);
         }


### PR DESCRIPTION
Fixes the issue with BountifulAPI's actionbar in 1.16.1 by using Spigot's ChatComponentAPI.
I've also uncoupled the actionbar live time and the scoreboard live time, so both can be enabled/disabled independently.