### PR TITLE
fix path for 3rd party plugins

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/plugin/PluginWrapper.java
+++ b/src/main/java/io/github/a5h73y/parkour/plugin/PluginWrapper.java
@@ -33,7 +33,7 @@ public abstract class PluginWrapper {
 	 */
 	protected void initialise() {
 		// if the config prevents integration, don't begin setup.
-		if (!Parkour.getDefaultConfig().getBoolean(getPluginName() + ".Enabled")) {
+		if (!Parkour.getDefaultConfig().getBoolean("Other." + getPluginName() + ".Enabled")) {
 			return;
 		}
 


### PR DESCRIPTION
Corrects path allowing PlaceholderAPI and other 3rd party plugins to be linked.