### PR TITLE
fix scoreboard issues

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/manager/ScoreboardManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/manager/ScoreboardManager.java
@@ -222,12 +222,12 @@ public class ScoreboardManager extends AbstractPluginReceiver {
     }
 
     private String convertTitle(String title) {
-        title = titleFormat.replace("%TITLE%", title);
+        title = titleFormat.replace("%VALUE%", title);
         return cropAndColour(title);
     }
 
     private String convertText(String value) {
-        value = textFormat.replace("%TEXT%", value);
+        value = textFormat.replace("%VALUE%", value);
         return cropAndColour(value);
     }
 

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -308,6 +308,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 
 		forceVisible(player);
 		parkour.getScoreboardManager().removeScoreboard(player);
+		removeParkourSession(player);
 		Bukkit.getServer().getPluginManager().callEvent(new PlayerLeaveCourseEvent(player, session.getCourse().getName()));
 	}
 
@@ -507,6 +508,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 
 		forceVisible(player);
 		parkour.getScoreboardManager().removeScoreboard(player);
+		removeParkourSession(player);
 		Bukkit.getServer().getPluginManager().callEvent(new PlayerFinishCourseEvent(player, courseName));
 	}
 
@@ -1288,6 +1290,19 @@ public class PlayerManager extends AbstractPluginReceiver {
 			}
 		}
 		return session;
+	}
+
+	private void removeParkourSession(Player player) {
+		File sessionFile = new File(getSessionsPath(), player.getUniqueId().toString());
+
+		if (sessionFile.exists()) {
+			try {
+				sessionFile.delete();
+			} catch (SecurityException e) {
+				PluginUtils.log("Player's session couldn't be deleted: " + e.getMessage(), 2);
+				e.printStackTrace();
+			}
+		}
 	}
 
 	/**

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -308,7 +308,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 
 		forceVisible(player);
 		parkour.getScoreboardManager().removeScoreboard(player);
-		removeParkourSession(player);
+		deleteParkourSession(player);
 		Bukkit.getServer().getPluginManager().callEvent(new PlayerLeaveCourseEvent(player, session.getCourse().getName()));
 	}
 
@@ -508,7 +508,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 
 		forceVisible(player);
 		parkour.getScoreboardManager().removeScoreboard(player);
-		removeParkourSession(player);
+		deleteParkourSession(player);
 		Bukkit.getServer().getPluginManager().callEvent(new PlayerFinishCourseEvent(player, courseName));
 	}
 
@@ -1292,7 +1292,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 		return session;
 	}
 
-	private void removeParkourSession(Player player) {
+	private void deleteParkourSession(Player player) {
 		File sessionFile = new File(getSessionsPath(), player.getUniqueId().toString());
 
 		if (sessionFile.exists()) {


### PR DESCRIPTION
Fixes the following 2 issues:
Scoreboard displays multiple %VALUE% lines due to mismatch in placeholder names between code and strings.yml.

Once a player has a session file created, it is never removed.  So after rejoining and completing or leaving the course, the session file remains. On next login the Parkour scoreboard is displayed even though the player is not on a course.