### PR TITLE
fixes 'course not found in database' error

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/database/ParkourDatabase.java
+++ b/src/main/java/io/github/a5h73y/parkour/database/ParkourDatabase.java
@@ -58,7 +58,7 @@ public class ParkourDatabase extends AbstractPluginReceiver {
      */
     public int getCourseId(String courseName, boolean printError) {
         if (courseIdCache.containsKey(courseName.toLowerCase())) {
-            PluginUtils.debug("Cached value found for " + courseName);
+            PluginUtils.debug("Cached value found for " + courseName + ": " + courseIdCache.get(courseName.toLowerCase()));
             return courseIdCache.get(courseName.toLowerCase());
         }
 
@@ -71,7 +71,9 @@ public class ParkourDatabase extends AbstractPluginReceiver {
                 courseId = rs.getInt("courseId");
             }
             rs.getStatement().close();
-            courseIdCache.put(courseName.toLowerCase(), courseId);
+            if (courseId != -1) {
+                courseIdCache.put(courseName.toLowerCase(), courseId);
+            }
         } catch (SQLException e) {
             logSqlException(e);
         }

--- a/src/main/java/io/github/a5h73y/parkour/plugin/PluginWrapper.java
+++ b/src/main/java/io/github/a5h73y/parkour/plugin/PluginWrapper.java
@@ -49,7 +49,7 @@ public abstract class PluginWrapper {
 
 		} else {
 			PluginUtils.log("[" + getPluginName() + "] Plugin is missing, disabling config option.", 1);
-			Parkour.getDefaultConfig().set(getPluginName() + ".Enabled", false);
+			Parkour.getDefaultConfig().set("Other." + getPluginName() + ".Enabled", false);
 			Parkour.getDefaultConfig().save();
 		}
 	}


### PR DESCRIPTION
This (hopefully) fixes the issue mentioned on discord a few times where a course has been created and a time set, but the leaderboard command says there are no times. This can happen when a 3rd party plugin (in this case ParkourTopTen) tries to get course information from an empty database.
```
[22:20:03] [Server thread/WARN]: [Parkour] Course 'orange' was not found in the database. Run command '/pa recreate' to fix.
```

Recreation:

- Start with a fresh install, i.e. empty database.
- Start server. 
- Lets say ParkourTopTen has a config entry for a Parkour course that we forgot to remove  - it will try to refresh the heads display by calling `Parkour.getInstance().getDatabase().getTopCourseResults(courseName.toLowerCase(), 10);`
- This calls the  `getCourseId` method which caches the course with an Id of -1.
- Then creating a course with the same name will succeed but the fact its already cached with a Id of -1 prevents any times being inserted into the database.


Unrelated to above, corrected the path name in PluginWrapper.

