### PR TITLE
save and restore players xp level

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -1432,10 +1432,10 @@ public class PlayerManager extends AbstractPluginReceiver {
 	 * @param player
 	 */
 	private void saveHealth(Player player) {
-		ParkourConfiguration config = Parkour.getConfig(ConfigType.INVENTORY);
-		config.set(player.getName() + ".Health", player.getHealth());
-		config.set(player.getName() + ".Hunger", player.getFoodLevel());
-		config.save();
+		ParkourConfiguration inventoryConfig = Parkour.getConfig(ConfigType.INVENTORY);
+		inventoryConfig.set(player.getName() + ".Health", player.getHealth());
+		inventoryConfig.set(player.getName() + ".Hunger", player.getFoodLevel());
+		inventoryConfig.save();
 	}
 
 	/**
@@ -1446,14 +1446,14 @@ public class PlayerManager extends AbstractPluginReceiver {
 	 * @param player
 	 */
 	private void restoreHealth(Player player) {
-		ParkourConfiguration invConfig = Parkour.getConfig(ConfigType.INVENTORY);
+		ParkourConfiguration inventoryConfig = Parkour.getConfig(ConfigType.INVENTORY);
 
-		double health = Math.min(player.getMaxHealth(), invConfig.getDouble(player.getName() + ".Health"));
+		double health = Math.min(player.getMaxHealth(), inventoryConfig.getDouble(player.getName() + ".Health"));
 		player.setHealth(health);
-		player.setFoodLevel(invConfig.getInt(player.getName() + ".Hunger"));
-		invConfig.set(player.getName() + ".Health", null);
-		invConfig.set(player.getName() + ".Hunger", null);
-		invConfig.save();
+		player.setFoodLevel(inventoryConfig.getInt(player.getName() + ".Hunger"));
+		inventoryConfig.set(player.getName() + ".Health", null);
+		inventoryConfig.set(player.getName() + ".Hunger", null);
+		inventoryConfig.save();
 	}
 
 	/**
@@ -1463,9 +1463,9 @@ public class PlayerManager extends AbstractPluginReceiver {
 	 * @param player
 	 */
 	private void saveXPLevel(Player player) {
-		ParkourConfiguration config = Parkour.getConfig(ConfigType.INVENTORY);
-		config.set(player.getName() + ".XPLevel", player.getLevel());
-		config.save();
+		ParkourConfiguration inventoryConfig = Parkour.getConfig(ConfigType.INVENTORY);
+		inventoryConfig.set(player.getName() + ".XPLevel", player.getLevel());
+		inventoryConfig.save();
 	}
 
 	/**
@@ -1476,10 +1476,10 @@ public class PlayerManager extends AbstractPluginReceiver {
 	 * @param player
 	 */
 	private void restoreXPLevel(Player player) {
-		ParkourConfiguration invConfig = Parkour.getConfig(ConfigType.INVENTORY);
-		player.setLevel(invConfig.getInt(player.getName() + ".XPLevel"));
-		invConfig.set(player.getName() + ".XPLevel", null);
-		invConfig.save();
+		ParkourConfiguration inventoryConfig = Parkour.getConfig(ConfigType.INVENTORY);
+		player.setLevel(inventoryConfig.getInt(player.getName() + ".XPLevel"));
+		inventoryConfig.set(player.getName() + ".XPLevel", null);
+		inventoryConfig.save();
 	}
 
 	private boolean hasDisplayPermission(Player player, Permission permission) {

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -1042,7 +1042,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 
 		player.updateInventory();
 
-		Parkour.getConfig(ConfigType.INVENTORY).set(player.getName(), null);
+		Parkour.getConfig(ConfigType.INVENTORY).set(player.getUniqueId().toString(), null);
 		Parkour.getConfig(ConfigType.INVENTORY).save();
 	}
 
@@ -1433,8 +1433,8 @@ public class PlayerManager extends AbstractPluginReceiver {
 	 */
 	private void saveHealth(Player player) {
 		ParkourConfiguration inventoryConfig = Parkour.getConfig(ConfigType.INVENTORY);
-		inventoryConfig.set(player.getName() + ".Health", player.getHealth());
-		inventoryConfig.set(player.getName() + ".Hunger", player.getFoodLevel());
+		inventoryConfig.set(player.getUniqueId() + ".Health", player.getHealth());
+		inventoryConfig.set(player.getUniqueId() + ".Hunger", player.getFoodLevel());
 		inventoryConfig.save();
 	}
 
@@ -1448,11 +1448,11 @@ public class PlayerManager extends AbstractPluginReceiver {
 	private void restoreHealth(Player player) {
 		ParkourConfiguration inventoryConfig = Parkour.getConfig(ConfigType.INVENTORY);
 
-		double health = Math.min(player.getMaxHealth(), inventoryConfig.getDouble(player.getName() + ".Health"));
+		double health = Math.min(player.getMaxHealth(), inventoryConfig.getDouble(player.getUniqueId() + ".Health"));
 		player.setHealth(health);
-		player.setFoodLevel(inventoryConfig.getInt(player.getName() + ".Hunger"));
-		inventoryConfig.set(player.getName() + ".Health", null);
-		inventoryConfig.set(player.getName() + ".Hunger", null);
+		player.setFoodLevel(inventoryConfig.getInt(player.getUniqueId() + ".Hunger"));
+		inventoryConfig.set(player.getUniqueId() + ".Health", null);
+		inventoryConfig.set(player.getUniqueId() + ".Hunger", null);
 		inventoryConfig.save();
 	}
 
@@ -1464,7 +1464,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 	 */
 	private void saveXPLevel(Player player) {
 		ParkourConfiguration inventoryConfig = Parkour.getConfig(ConfigType.INVENTORY);
-		inventoryConfig.set(player.getName() + ".XPLevel", player.getLevel());
+		inventoryConfig.set(player.getUniqueId() + ".XPLevel", player.getLevel());
 		inventoryConfig.save();
 	}
 
@@ -1477,8 +1477,8 @@ public class PlayerManager extends AbstractPluginReceiver {
 	 */
 	private void restoreXPLevel(Player player) {
 		ParkourConfiguration inventoryConfig = Parkour.getConfig(ConfigType.INVENTORY);
-		player.setLevel(inventoryConfig.getInt(player.getName() + ".XPLevel"));
-		inventoryConfig.set(player.getName() + ".XPLevel", null);
+		player.setLevel(inventoryConfig.getInt(player.getUniqueId() + ".XPLevel"));
+		inventoryConfig.set(player.getUniqueId() + ".XPLevel", null);
 		inventoryConfig.save();
 	}
 


### PR DESCRIPTION
If `SetXPBarToDeathCount` is true, XP level is saved to inventory.yml (as are health and hunger levels).

The inventory was being saved with a uuid key, while health and hunger were saved with the player name key. Everything is now saved under the same uuid key.

On restore, each key value is cleared. The inventory restore has to be done last as it clears the whole player uuid record.