### PR TITLE
fix reward delay

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/utility/DateTimeUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utility/DateTimeUtils.java
@@ -6,6 +6,7 @@ import io.github.a5h73y.parkour.type.player.PlayerInfo;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+
 import org.bukkit.OfflinePlayer;
 
 /**
@@ -76,9 +77,9 @@ public class DateTimeUtils {
 		MillisecondConverter time = new MillisecondConverter(millis);
 		StringBuilder totalTime = new StringBuilder();
 
-		if (time.getDays() > 2) {
+		if (time.getDays() > 1) {
 			totalTime.append(time.getDays());
-			totalTime.append(" days"); //todo translate
+			totalTime.append(" days"); //TODO translate
 			return totalTime.toString();
 		}
 
@@ -96,7 +97,7 @@ public class DateTimeUtils {
 	}
 
 	public static long convertDaysToMilliseconds(int days) {
-		return days * 86400000; //(24*60*60*1000)
+		return days * 86400000L; //(24*60*60*1000)
 	}
 
 }


### PR DESCRIPTION
We're overflowing max int when converting days to milliseconds if days > 24.
When there are 2 days and some hours left, it displays "1 day .... "