### PR TITLE
Fix for issues relating to cached courses

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/conversation/EditParkourKitConversation.java
+++ b/src/main/java/io/github/a5h73y/parkour/conversation/EditParkourKitConversation.java
@@ -86,6 +86,7 @@ public class EditParkourKitConversation extends ParkourConversation {
             Parkour.getConfig(ConfigType.PARKOURKIT).set("ParkourKit." + kitName + "." + material, null);
             Parkour.getConfig(ConfigType.PARKOURKIT).save();
             Parkour.getInstance().getParkourKitManager().clearMemory(kitName);
+            Parkour.getInstance().getCourseManager().clearCache();
             context.getForWhom().sendRawMessage(Parkour.getPrefix() + material + " removed from " + kitName);
             return new ChooseOption(true);
         }

--- a/src/main/java/io/github/a5h73y/parkour/conversation/EditParkourKitConversation.java
+++ b/src/main/java/io/github/a5h73y/parkour/conversation/EditParkourKitConversation.java
@@ -3,6 +3,7 @@ package io.github.a5h73y.parkour.conversation;
 import io.github.a5h73y.parkour.Parkour;
 import io.github.a5h73y.parkour.conversation.other.AddKitItemConversation;
 import io.github.a5h73y.parkour.enums.ConfigType;
+import io.github.a5h73y.parkour.type.course.CourseInfo;
 import io.github.a5h73y.parkour.type.kit.ParkourKitInfo;
 import org.bukkit.ChatColor;
 import org.bukkit.conversations.ConversationContext;
@@ -86,7 +87,9 @@ public class EditParkourKitConversation extends ParkourConversation {
             Parkour.getConfig(ConfigType.PARKOURKIT).set("ParkourKit." + kitName + "." + material, null);
             Parkour.getConfig(ConfigType.PARKOURKIT).save();
             Parkour.getInstance().getParkourKitManager().clearMemory(kitName);
-            Parkour.getInstance().getCourseManager().clearCache();
+            for (String courseName : CourseInfo.getDependentCourses(kitName)) {
+                Parkour.getInstance().getCourseManager().clearCache(courseName);
+            }
             context.getForWhom().sendRawMessage(Parkour.getPrefix() + material + " removed from " + kitName);
             return new ChooseOption(true);
         }

--- a/src/main/java/io/github/a5h73y/parkour/conversation/ParkourModeConversation.java
+++ b/src/main/java/io/github/a5h73y/parkour/conversation/ParkourModeConversation.java
@@ -1,5 +1,6 @@
 package io.github.a5h73y.parkour.conversation;
 
+import io.github.a5h73y.parkour.Parkour;
 import io.github.a5h73y.parkour.type.course.CourseInfo;
 import io.github.a5h73y.parkour.utility.TranslationUtils;
 import org.bukkit.ChatColor;
@@ -37,6 +38,7 @@ public class ParkourModeConversation extends ParkourConversation {
             String courseName = (String) context.getSessionData("courseName");
 
             CourseInfo.setMode(courseName, choice);
+            Parkour.getInstance().getCourseManager().clearCache(courseName);
 
             context.getForWhom().sendRawMessage(TranslationUtils.getTranslation("Parkour.SetMode")
                     .replace("%COURSE%", courseName)

--- a/src/main/java/io/github/a5h73y/parkour/conversation/other/AddKitItemConversation.java
+++ b/src/main/java/io/github/a5h73y/parkour/conversation/other/AddKitItemConversation.java
@@ -187,6 +187,7 @@ public class AddKitItemConversation {
 
             context.getForWhom().sendRawMessage(Parkour.getPrefix() + kitName + " ParkourKit has been successfully saved.");
             Parkour.getInstance().getParkourKitManager().clearMemory(kitName);
+            Parkour.getInstance().getCourseManager().clearCache();
             return endingConversation;
         }
     }

--- a/src/main/java/io/github/a5h73y/parkour/conversation/other/AddKitItemConversation.java
+++ b/src/main/java/io/github/a5h73y/parkour/conversation/other/AddKitItemConversation.java
@@ -4,6 +4,7 @@ import io.github.a5h73y.parkour.Parkour;
 import io.github.a5h73y.parkour.configuration.ParkourConfiguration;
 import io.github.a5h73y.parkour.conversation.ParkourConversation;
 import io.github.a5h73y.parkour.enums.ConfigType;
+import io.github.a5h73y.parkour.type.course.CourseInfo;
 import io.github.a5h73y.parkour.utility.MaterialUtils;
 import java.util.HashMap;
 import java.util.Map;
@@ -187,7 +188,9 @@ public class AddKitItemConversation {
 
             context.getForWhom().sendRawMessage(Parkour.getPrefix() + kitName + " ParkourKit has been successfully saved.");
             Parkour.getInstance().getParkourKitManager().clearMemory(kitName);
-            Parkour.getInstance().getCourseManager().clearCache();
+            for (String courseName : CourseInfo.getDependentCourses(kitName)) {
+                Parkour.getInstance().getCourseManager().clearCache(courseName);
+            }
             return endingConversation;
         }
     }

--- a/src/main/java/io/github/a5h73y/parkour/other/Validation.java
+++ b/src/main/java/io/github/a5h73y/parkour/other/Validation.java
@@ -452,15 +452,7 @@ public class Validation {
         }
 
         parkourKit = parkourKit.toLowerCase();
-        List<String> dependentCourses = new ArrayList<>();
-
-        for (String course : CourseInfo.getAllCourses()) {
-            String linkedKit = CourseInfo.getParkourKit(course);
-
-            if (parkourKit.equals(linkedKit)) {
-                dependentCourses.add(course);
-            }
-        }
+        List<String> dependentCourses = CourseInfo.getDependentCourses(parkourKit);
 
         if (dependentCourses.size() > 0) {
             player.sendMessage(Parkour.getPrefix() + "This ParkourKit can not be deleted as there are dependent courses: " + dependentCourses);

--- a/src/main/java/io/github/a5h73y/parkour/type/checkpoint/CheckpointManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/checkpoint/CheckpointManager.java
@@ -189,6 +189,7 @@ public class CheckpointManager extends AbstractPluginReceiver {
         checkpointsConfig.set(courseName + "." + point, null);
         checkpointsConfig.set(courseName + ".Checkpoints", point - 1);
         checkpointsConfig.save();
+        parkour.getCourseManager().clearCache(courseName);
 
         player.sendMessage(TranslationUtils.getTranslation("Parkour.DeleteCheckpoint")
                 .replace("%CHECKPOINT%", String.valueOf(point))

--- a/src/main/java/io/github/a5h73y/parkour/type/course/CourseInfo.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/course/CourseInfo.java
@@ -51,6 +51,22 @@ public class CourseInfo {
     }
 
     /**
+     * Get list of Parkour courses linked to a Parkour kit.
+     * @param parkourKit
+     * @return List Parkour course names
+     */
+    public static List<String> getDependentCourses(String parkourKit) {
+        List<String> dependentCourses = new ArrayList<>();
+        for (String course : getAllCourses()) {
+            String linkedKit = CourseInfo.getParkourKit(course);
+            if (parkourKit.equals(linkedKit)) {
+                dependentCourses.add(course);
+            }
+        }
+        return dependentCourses;
+    }
+
+    /**
      * Check if Course is linked to another Course.
      *
      * @param courseName

--- a/src/main/java/io/github/a5h73y/parkour/type/course/CourseManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/course/CourseManager.java
@@ -488,6 +488,7 @@ public class CourseManager extends AbstractPluginReceiver {
         }
 
         CourseInfo.setMaximumDeaths(args[1], Integer.parseInt(args[2]));
+        clearCache(args[1]);
         sender.sendMessage(Parkour.getPrefix() + ChatColor.AQUA + args[1] + ChatColor.WHITE + " maximum deaths was set to " + ChatColor.AQUA + args[2]);
     }
 
@@ -516,6 +517,7 @@ public class CourseManager extends AbstractPluginReceiver {
 
         int seconds = Integer.parseInt(args[2]);
         CourseInfo.setMaximumTime(args[1], seconds);
+        clearCache(args[1]);
         sender.sendMessage(Parkour.getPrefix() + ChatColor.AQUA + args[1] + ChatColor.WHITE + " maximum time limit was set to "
                 + ChatColor.AQUA + DateTimeUtils.convertSecondsToTime(seconds));
     }
@@ -783,6 +785,7 @@ public class CourseManager extends AbstractPluginReceiver {
         }
 
         CourseInfo.setParkourKit(args[1], args[2]);
+        clearCache(args[1]);
         player.sendMessage(Parkour.getPrefix() + args[1] + " is now linked to ParkourKit " + args[2]);
     }
 


### PR DESCRIPTION
Once a course is cached, changes made to anything in the course object (parkour kit changes, setting maxtime/maxdeath, setting a parkour mode, and adding/removing checkpoints) are not being  passed to it. So, after making these changes, the affected course(s) should be removed from the course cache.