### PR TITLE
increase min args required for commands

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/commands/ParkourCommands.java
+++ b/src/main/java/io/github/a5h73y/parkour/commands/ParkourCommands.java
@@ -601,7 +601,7 @@ public class ParkourCommands extends AbstractPluginReceiver implements CommandEx
             case "setmaxtime":
             case "setmaxdeath":
             case "setcreator":
-                if (!ValidationUtils.validateArgs(player, args, 1, 3)) {
+                if (!ValidationUtils.validateArgs(player, args, 3)) {
                     return false;
                 }
 
@@ -610,7 +610,7 @@ public class ParkourCommands extends AbstractPluginReceiver implements CommandEx
 
             case "setrank":
             case "setlevel":
-                if (!ValidationUtils.validateArgs(player, args, 1, 3)) {
+                if (!ValidationUtils.validateArgs(player, args, 3)) {
                     return false;
                 }
 


### PR DESCRIPTION
Running the 'replaced' course commands without any arguments causes a index out of bounds exception.
Minimum number of arguments should be 3 in all cases.