### PR TITLE
fix for scoreboard timer with max time

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/manager/ScoreboardManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/manager/ScoreboardManager.java
@@ -102,6 +102,11 @@ public class ScoreboardManager extends AbstractPluginReceiver {
             return;
         }
 
+        if (board.getTeam(MAX_TIME) != null) {
+            board.getTeam(MAX_TIME).setPrefix(convertText(liveTime));
+            return;
+        }
+
         board.getTeam(CURRENT_TIME).setPrefix(convertText(liveTime));
     }
 


### PR DESCRIPTION
If live time is enabled on the scoreboard for a course with a max-time, the initial time gets added to the scoreboard but never gets updated. Also causes the actionbar timer to not stop at zero.

Check if the course has a max time, then update scoreboard MAX_TIME .