### PR TITLE
only display new record title if enabled in config 

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/commands/ParkourAutoTabCompleter.java
+++ b/src/main/java/io/github/a5h73y/parkour/commands/ParkourAutoTabCompleter.java
@@ -50,6 +50,9 @@ public class ParkourAutoTabCompleter extends AbstractPluginReceiver implements T
     private static final List<String> LIST_COMMANDS = Arrays.asList(
             "courses", "players", "ranks", "lobbies");
 
+    private static final List<String> ECONOMY_COMMANDS = Arrays.asList(
+            "info", "recreate", "setprize", "setfee");
+
     public ParkourAutoTabCompleter(Parkour parkour) {
         super(parkour);
     }
@@ -165,6 +168,9 @@ public class ParkourAutoTabCompleter extends AbstractPluginReceiver implements T
                 break;
             case "list":
                 allowedCommands = LIST_COMMANDS;
+                break;
+            case "economy":
+                allowedCommands = ECONOMY_COMMANDS;
                 break;
             case "join":
             case "course":

--- a/src/main/java/io/github/a5h73y/parkour/database/ParkourDatabase.java
+++ b/src/main/java/io/github/a5h73y/parkour/database/ParkourDatabase.java
@@ -210,6 +210,7 @@ public class ParkourDatabase extends AbstractPluginReceiver {
         } catch (SQLException e) {
             logSqlException(e);
         }
+        PluginUtils.debug("Leaderboard position is: " + position);
         return position;
     }
 
@@ -233,7 +234,7 @@ public class ParkourDatabase extends AbstractPluginReceiver {
      * @return is best course time
      */
     public boolean isBestCourseTime(String courseName, long time) {
-        return getPositionOnLeaderboard(courseName, time) == 0; //TODO test
+        return getPositionOnLeaderboard(courseName, time) == 1; //TODO test
     }
 
     /**
@@ -244,7 +245,7 @@ public class ParkourDatabase extends AbstractPluginReceiver {
      * @return is best course time
      */
     public boolean isBestCourseTime(OfflinePlayer player, String courseName, long time) {
-        return getPositionOnLeaderboard(player, courseName, time) == 0; //TODO test
+        return getPositionOnLeaderboard(player, courseName, time) == 1; //TODO test
     }
 
     /**

--- a/src/main/java/io/github/a5h73y/parkour/plugin/BountifulApi.java
+++ b/src/main/java/io/github/a5h73y/parkour/plugin/BountifulApi.java
@@ -65,11 +65,11 @@ public class BountifulApi extends PluginWrapper {
 		}
 
 		if (attemptTitle) {
-			if (isEnabled()) {
-				BountifulAPI.sendTitle(player, inDuration, stayDuration, outDuration, title, subTitle);
-
-			} else if (useSpigotMethods) {
+			if (useSpigotMethods) {
 				player.sendTitle(title, subTitle, inDuration, stayDuration, outDuration);
+
+			} else if (isEnabled()) {
+				BountifulAPI.sendTitle(player, inDuration, stayDuration, outDuration, title, subTitle);
 			}
 		} else {
 			player.sendMessage(Parkour.getPrefix() + title);
@@ -82,11 +82,11 @@ public class BountifulApi extends PluginWrapper {
 		}
 
 		if (attemptTitle) {
-			if (isEnabled()) {
-				BountifulAPI.sendActionBar(player, title);
-
-			} else if (useSpigotMethods) {
+			if (useSpigotMethods) {
 				player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(title));
+
+			} else if (isEnabled()) {
+				BountifulAPI.sendActionBar(player, title);
 			}
 		} else {
 			player.sendMessage(Parkour.getPrefix() + title);

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -1621,16 +1621,20 @@ public class PlayerManager extends AbstractPluginReceiver {
 		}
 
 		if (parkour.getDatabase().isBestCourseTime(session.getCourse().getName(), session.getTimeFinished())) {
-			parkour.getBountifulApi().sendFullTitle(player,
-					TranslationUtils.getTranslation("Parkour.CourseRecord", false),
-					DateTimeUtils.displayCurrentTime(session.getTimeFinished()), true);
+			if (parkour.getConfig().getBoolean("OnFinish.DisplayNewRecords")) {
+				parkour.getBountifulApi().sendFullTitle(player,
+						TranslationUtils.getTranslation("Parkour.CourseRecord", false),
+						DateTimeUtils.displayCurrentTime(session.getTimeFinished()), true);
+			}
 			return true;
 		}
 
 		if (parkour.getDatabase().isBestCourseTime(player, session.getCourse().getName(), session.getTimeFinished())) {
-			parkour.getBountifulApi().sendFullTitle(player,
-					TranslationUtils.getTranslation("Parkour.BestTime", false),
-					DateTimeUtils.displayCurrentTime(session.getTimeFinished()), true);
+			if (parkour.getConfig().getBoolean("OnFinish.DisplayNewRecords")) {
+				parkour.getBountifulApi().sendFullTitle(player,
+						TranslationUtils.getTranslation("Parkour.BestTime", false),
+						DateTimeUtils.displayCurrentTime(session.getTimeFinished()), true);
+			}
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Started looking at why, if 'UpdatePlayerDatabaseTime' was true, the time wasn't being inserted into the database. Turns out it was because isBestCourseTime would always returns false  (it's marked as TODO). Not sure if there was anything else you wanted to add apart from checking for position 1. 

Added check if DisplayNewRecords is true.

Reversed the order when checking if BountifulAPI is enabled for actionbar and titles, as the vast majority can use the spigot method - not sure how much real difference it makes but logically seems right (to me anyway).