### PR TITLE
updates to Parkour join GUI

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
@@ -126,6 +126,7 @@ public class DefaultConfig extends ParkourConfiguration {
 		this.addDefault("ParkourGUI.Enabled", false);
 		this.addDefault("ParkourGUI.Rows", 2);
 		this.addDefault("ParkourGUI.Material", "BOOK");
+		this.addDefault("ParkourGUI.FillerMaterial", "CYAN_STAINED_GLASS_PANE");
 
 		this.addDefault("Other.CheckForUpdates", true);
 		this.addDefault("Other.LogToFile", true);
@@ -320,6 +321,10 @@ public class DefaultConfig extends ParkourConfiguration {
 
 	public Material getGuiMaterial() {
 		return getMaterialOrDefault("ParkourGUI.Material", Material.BOOK);
+	}
+
+	public Material getGuiFillerMaterial() {
+		return getMaterialOrDefault("ParkourGUI.FillerMaterial", Material.AIR);
 	}
 
 	private Material getMaterialOrDefault(String configPath, Material defaultMaterial) {

--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/StringsConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/StringsConfig.java
@@ -174,6 +174,8 @@ public class StringsConfig extends ParkourConfiguration {
 		this.addDefault("GUI.JoinCourses.Setup.Line2", " ggggggg ");
 		this.addDefault("GUI.JoinCourses.Setup.Line3", "  fp nl  ");
 		this.addDefault("GUI.JoinCourses.Description", "&fJoin &b%VALUE%");
+		this.addDefault("GUI.JoinCourses.Players", "Players: &b%VALUE%");
+		this.addDefault("GUI.JoinCourses.Checkpoints", "Checkpoints: &b%VALUE%");
 
 
 		this.addDefault("Display.TimeFormat", "HH:mm:ss:MMM");

--- a/src/main/java/io/github/a5h73y/parkour/gui/JoinCourses.java
+++ b/src/main/java/io/github/a5h73y/parkour/gui/JoinCourses.java
@@ -7,7 +7,7 @@ import io.github.a5h73y.parkour.Parkour;
 import io.github.a5h73y.parkour.type.course.CourseInfo;
 import io.github.a5h73y.parkour.utility.StringUtils;
 import io.github.a5h73y.parkour.utility.TranslationUtils;
-import org.bukkit.Material;
+
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -37,7 +37,7 @@ public class JoinCourses extends AbstractMenu {
 		for (String course : CourseInfo.getAllCourses()) {
 			group.addElement(
 					new StaticGuiElement('e',
-							new ItemStack(Material.MINECART),
+							new ItemStack(Parkour.getDefaultConfig().getGuiMaterial()),
 							click -> {
 								Parkour.getInstance().getPlayerManager().joinCourse(player, course);
 								parent.close();
@@ -49,7 +49,11 @@ public class JoinCourses extends AbstractMenu {
 
 							// the item description
 							TranslationUtils.getValueTranslation("GUI.JoinCourses.Description",
-									course, false)
+									course, false),
+							TranslationUtils.getValueTranslation("GUI.JoinCourses.Players",
+									String.valueOf(Parkour.getInstance().getPlayerManager().getNumberOfPlayersOnCourse(course)), false),
+							TranslationUtils.getValueTranslation("GUI.JoinCourses.Checkpoints",
+									String.valueOf(Parkour.getInstance().getCourseManager().getCourse(course).getNumberOfCheckpoints()), false)
 					));
 		}
 		return group;

--- a/src/main/java/io/github/a5h73y/parkour/gui/JoinCourses.java
+++ b/src/main/java/io/github/a5h73y/parkour/gui/JoinCourses.java
@@ -53,7 +53,7 @@ public class JoinCourses extends AbstractMenu {
 							TranslationUtils.getValueTranslation("GUI.JoinCourses.Players",
 									String.valueOf(Parkour.getInstance().getPlayerManager().getNumberOfPlayersOnCourse(course)), false),
 							TranslationUtils.getValueTranslation("GUI.JoinCourses.Checkpoints",
-									String.valueOf(Parkour.getInstance().getCourseManager().getCourse(course).getNumberOfCheckpoints()), false)
+									String.valueOf(CourseInfo.getCheckpointAmount(course)), false)
 					));
 		}
 		return group;

--- a/src/main/java/io/github/a5h73y/parkour/gui/ParkourGuiManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/gui/ParkourGuiManager.java
@@ -38,7 +38,7 @@ public class ParkourGuiManager extends AbstractPluginReceiver {
 	 */
 	public void showMenu(Player player, AbstractMenu menu) {
 		InventoryGui gui = new InventoryGui(parkour, null, PARKOUR_TITLE_PREFIX + menu.getTitle(), menu.getGuiSetup());
-		gui.setFiller(new ItemStack(Material.GRAY_STAINED_GLASS, 1));
+		gui.setFiller(new ItemStack(Parkour.getDefaultConfig().getGuiFillerMaterial(), 1));
 
 		gui.addElement(menu.getGroupContent(gui, player));
 

--- a/src/main/java/io/github/a5h73y/parkour/plugin/BountifulApi.java
+++ b/src/main/java/io/github/a5h73y/parkour/plugin/BountifulApi.java
@@ -27,7 +27,7 @@ public class BountifulApi extends PluginWrapper {
 	protected void initialise() {
 		super.initialise();
 
-		useSpigotMethods = PluginUtils.getMinorServerVersion() > 9;
+		useSpigotMethods = PluginUtils.getMinorServerVersion() > 10;
 		inDuration = Parkour.getDefaultConfig().getTitleIn();
 		stayDuration = Parkour.getDefaultConfig().getTitleStay();
 		outDuration = Parkour.getDefaultConfig().getTitleOut();

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -1447,6 +1447,19 @@ public class PlayerManager extends AbstractPluginReceiver {
 		}
 	}
 
+	public int getNumberOfPlayersOnCourse(String course) {
+		if (getNumberOfParkourPlayer() == 0) {
+			return 0;
+		}
+		int count = 0;
+		for (Map.Entry<Player, ParkourSession> entry : parkourPlayers.entrySet()) {
+			if (entry.getValue().getCourse().getName().equalsIgnoreCase(course)) {
+				count++;
+			}
+		}
+		return count;
+	}
+
 	private File getSessionsPath() {
 		return new File(parkour.getDataFolder() + File.separator + "sessions" + File.separator);
 	}


### PR DESCRIPTION
This makes the GUI look less cluttered by default, and reverts it to using a book instead of a minecart. The book and glass_pane items are configurable, and also added lore to the book/course item to display the number of players currently on the course and the number of checkpoints (text is also configurable in strings.yml). So the default GUI will change from this:

![image](https://user-images.githubusercontent.com/6975392/96749634-f7fbf580-13c2-11eb-9b22-5b2d8da65459.png)

to this:

![image](https://user-images.githubusercontent.com/6975392/96750132-83758680-13c3-11eb-9ba4-b0530f4dd5c2.png)

Tested on 1.8.8 through to 1.16.3. 
Noticed on 1.10 that titles didn't work, as Spigot method wasn't available until 1.11.