### PR TITLE
Join course silently when restarting a course

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
+++ b/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
@@ -183,7 +183,7 @@ public class ParkourPlaceholders extends PlaceholderExpansion {
 
         } else if (command.equals("current_course_timer")) {
             ParkourSession session = parkour.getPlayerManager().getParkourSession(player);
-            return session == null ? "" : session.displayTime();
+            return session == null ? "" : session.getDisplayTime();
 
         } else if (command.equals("current_course_deaths")) {
             ParkourSession session = parkour.getPlayerManager().getParkourSession(player);

--- a/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
+++ b/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
@@ -183,8 +183,7 @@ public class ParkourPlaceholders extends PlaceholderExpansion {
 
         } else if (command.equals("current_course_timer")) {
             ParkourSession session = parkour.getPlayerManager().getParkourSession(player);
-//            return session == null ? "" : session.getLiveTime(); TODO
-            return "";
+            return session == null ? "" : session.displayTime();
 
         } else if (command.equals("current_course_deaths")) {
             ParkourSession session = parkour.getPlayerManager().getParkourSession(player);

--- a/src/main/java/io/github/a5h73y/parkour/listener/PlayerInteractListener.java
+++ b/src/main/java/io/github/a5h73y/parkour/listener/PlayerInteractListener.java
@@ -6,8 +6,11 @@ import io.github.a5h73y.parkour.other.AbstractPluginReceiver;
 import io.github.a5h73y.parkour.type.checkpoint.Checkpoint;
 import io.github.a5h73y.parkour.type.player.ParkourSession;
 import io.github.a5h73y.parkour.utility.MaterialUtils;
+import io.github.a5h73y.parkour.utility.PluginUtils;
 import io.github.a5h73y.parkour.utility.TranslationUtils;
 import com.cryptomorin.xseries.XMaterial;
+
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -38,7 +41,7 @@ public class PlayerInteractListener extends AbstractPluginReceiver implements Li
             return;
         }
 
-        if (event.getHand() != EquipmentSlot.HAND) { //TODO is SneakToInteractItems is false, this acts super weird.
+        if (PluginUtils.getMinorServerVersion() > 8 && !event.getHand().equals(EquipmentSlot.HAND)) {
             return;
         }
 
@@ -60,7 +63,7 @@ public class PlayerInteractListener extends AbstractPluginReceiver implements Li
         if (materialInHand == parkour.getConfig().getLastCheckpointTool()) {
             if (parkour.getPlayerManager().delayPlayer(player, 1, false)) {
                 event.setCancelled(true);
-                parkour.getPlayerManager().playerDie(player);
+                Bukkit.getScheduler().runTask(parkour, () -> parkour.getPlayerManager().playerDie(player));
             }
 
         } else if (materialInHand == parkour.getConfig().getHideAllDisabledTool()

--- a/src/main/java/io/github/a5h73y/parkour/type/player/ParkourSession.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/ParkourSession.java
@@ -115,7 +115,7 @@ public class ParkourSession implements Serializable {
         return System.currentTimeMillis() - timeStarted;
     }
 
-    public String displayTime() {
+    public String getDisplayTime() {
         return DateTimeUtils.displayCurrentTime(getCurrentTime());
     }
 

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -1310,7 +1310,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 		if (session != null) {
 			player.sendMessage("Course: " + ChatColor.AQUA + session.getCourse().getName());
 			player.sendMessage("Deaths: " + ChatColor.AQUA + session.getDeaths());
-			player.sendMessage("Time: " + ChatColor.AQUA + session.displayTime());
+			player.sendMessage("Time: " + ChatColor.AQUA + session.getDisplayTime());
 			player.sendMessage("Checkpoint: " + ChatColor.AQUA + session.getCurrentCheckpoint());
 		}
 
@@ -1464,7 +1464,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 					.replace("%PLAYER%", entry.getKey().getName())
 					.replace("%COURSE%", entry.getValue().getCourse().getName())
 					.replace("%DEATHS%", String.valueOf(entry.getValue().getDeaths()))
-					.replace("%TIME%", entry.getValue().displayTime()));
+					.replace("%TIME%", entry.getValue().getDisplayTime()));
 		}
 	}
 
@@ -1491,7 +1491,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 					TranslationUtils.getCourseMessage(session.getCourse().getName(), "FinishMessage", "Parkour.FinishCourse1"),
 					TranslationUtils.getTranslation("Parkour.FinishCourse2", false)
 							.replace("%DEATHS%", String.valueOf(session.getDeaths()))
-							.replace("%TIME%", session.displayTime()),
+							.replace("%TIME%", session.getDisplayTime()),
 					parkour.getConfig().getBoolean("DisplayTitle.Finish"));
 		}
 
@@ -1505,7 +1505,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 				.replace("%PLAYER_DISPLAY%", player.getDisplayName())
 				.replace("%COURSE%", session.getCourse().getName())
 				.replace("%DEATHS%", String.valueOf(session.getDeaths()))
-				.replace("%TIME%", session.displayTime());
+				.replace("%TIME%", session.getDisplayTime());
 
 		switch (parkour.getConfig().getString("OnFinish.BroadcastLevel", "WORLD").toUpperCase()) {
 			case "GLOBAL":

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -292,9 +292,22 @@ public class PlayerManager extends AbstractPluginReceiver {
 	 * @param course target course
 	 */
 	public void joinCourse(Player player, Course course) {
-		if (parkour.getConfig().isTeleportToJoinLocation()) {
+		joinCourse(player, course, false);
+	}
+
+	/**
+	 * Join the Player to a Course.
+	 * Prepare the player for a Parkour course.
+	 *
+	 * @param player target player
+	 * @param course target course
+	 * @param silent silently join the course
+	 */
+	public void joinCourse(Player player, Course course, boolean silent) {
+		if (!silent && parkour.getConfig().isTeleportToJoinLocation()) {
 			PlayerInfo.setJoinLocation(player);
 		}
+
 		player.teleport(course.getCheckpoints().get(0).getLocation());
 		preparePlayerForCourse(player, course.getName());
 		CourseInfo.increaseView(course.getName());
@@ -309,7 +322,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 
 		// join message
 		if (!isInQuietMode(player)) {
-			if (isPlaying(player)) {
+			if (silent) {
 				TranslationUtils.sendTranslation("Parkour.TimeReset", player);
 
 			} else {
@@ -639,7 +652,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 		Course course = getParkourSession(player).getCourse();
 		TranslationUtils.sendTranslation("Parkour.Restarting", player);
 		leaveCourse(player, true);
-		joinCourse(player, course);
+		Bukkit.getScheduler().runTask(parkour, () -> joinCourse(player, course, true));
 	}
 
 	/**

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -321,39 +321,35 @@ public class PlayerManager extends AbstractPluginReceiver {
 		}
 
 		// join message
-		if (!isInQuietMode(player)) {
-			if (silent) {
-				TranslationUtils.sendTranslation("Parkour.TimeReset", player);
+		if (!isInQuietMode(player) && !silent) {
+			boolean displayTitle = parkour.getConfig().getBoolean("DisplayTitle.JoinCourse");
 
-			} else {
-				boolean displayTitle = parkour.getConfig().getBoolean("DisplayTitle.JoinCourse");
+			String subTitle = "";
+			if (course.hasMaxDeaths() && course.hasMaxTime()) {
+				subTitle = TranslationUtils.getTranslation("Parkour.JoinLivesAndTime", false)
+						.replace("%LIVES%", String.valueOf(course.getMaxDeaths()))
+						.replace("%MAXTIME%", DateTimeUtils.convertSecondsToTime(course.getMaxTime()));
 
-				String subTitle = "";
-				if (course.hasMaxDeaths() && course.hasMaxTime()) {
-					subTitle = TranslationUtils.getTranslation("Parkour.JoinLivesAndTime", false)
-							.replace("%LIVES%", String.valueOf(course.getMaxDeaths()))
-							.replace("%MAXTIME%", DateTimeUtils.convertSecondsToTime(course.getMaxTime()));
+			} else if (course.hasMaxDeaths()) {
+				subTitle = TranslationUtils.getValueTranslation(
+						"Parkour.JoinLives", String.valueOf(course.getMaxDeaths()), false);
 
-				} else if (course.hasMaxDeaths()) {
-					subTitle = TranslationUtils.getValueTranslation(
-							"Parkour.JoinLives", String.valueOf(course.getMaxDeaths()), false);
+			} else if (course.hasMaxTime()) {
+				subTitle = TranslationUtils.getValueTranslation(
+						"Parkour.JoinTime", DateTimeUtils.convertSecondsToTime(course.getMaxTime()), false);
+			}
 
-				} else if (course.hasMaxTime()) {
-					subTitle = TranslationUtils.getValueTranslation(
-							"Parkour.JoinTime", DateTimeUtils.convertSecondsToTime(course.getMaxTime()), false);
-				}
+			parkour.getBountifulApi().sendFullTitle(player,
+					TranslationUtils.getCourseMessage(course.getName(), "JoinMessage", "Parkour.Join"),
+					subTitle, displayTitle);
 
-				parkour.getBountifulApi().sendFullTitle(player,
-						TranslationUtils.getCourseMessage(course.getName(), "JoinMessage", "Parkour.Join"),
-						subTitle, displayTitle);
-
-				if (parkour.getConfig().isCompletedCoursesEnabled()
-						&& PlayerInfo.getCompletedCourses(player).contains(course.getName())
-						&& parkour.getConfig().getBoolean("Other.Display.CourseCompleted")) {
-					TranslationUtils.sendValueTranslation("Parkour.AlreadyCompleted", course.getName(), player);
-				}
+			if (parkour.getConfig().isCompletedCoursesEnabled()
+					&& PlayerInfo.getCompletedCourses(player).contains(course.getName())
+					&& parkour.getConfig().getBoolean("Other.Display.CourseCompleted")) {
+				TranslationUtils.sendValueTranslation("Parkour.AlreadyCompleted", course.getName(), player);
 			}
 		}
+
 
 		addPlayer(player, new ParkourSession(course));
 		setupParkourMode(player);

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -350,13 +350,11 @@ public class PlayerManager extends AbstractPluginReceiver {
 			}
 		}
 
-
 		addPlayer(player, new ParkourSession(course));
 		setupParkourMode(player);
 		parkour.getScoreboardManager().addScoreboard(player);
 		Bukkit.getServer().getPluginManager().callEvent(new PlayerJoinCourseEvent(player, course.getName()));
 	}
-
 
 	/**
 	 * Execute the joinCourse after a delay.

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -964,11 +964,11 @@ public class PlayerManager extends AbstractPluginReceiver {
 		}
 		if (enabled) {
 			removeHidden(player);
-			TranslationUtils.sendTranslation("Event.HideAll1");
+			TranslationUtils.sendTranslation("Event.HideAll1", player);
 
 		} else {
 			addHidden(player);
-			TranslationUtils.sendTranslation("Event.HideAll2");
+			TranslationUtils.sendTranslation("Event.HideAll2", player);
 		}
 	}
 


### PR DESCRIPTION
Add a silent option to joinCourse() for restarting a course;
The displayTime() method in ParkourSession is renamed to getDisplayTime();
Update/enable the placeholder _%current_course_timer%_;
Delay the teleport of players using the parkour tools by 1 tick to avoid issues with _PlayerInteractEvent_.

Fixes these issues when _restarting_ a course:

- wrong message displayed;
- message displayed twice (also when using back-to-last-checkpoint tool);
- join-from location getting overwritten;
- sometimes unexpected behaviour right-clicking parkour tools.

The `PlayerInteractListener#playerDie()` method (when right-clicking the checkpoint tool) is run as a task one tick later to avoid issues with teleport & PlayerInteractEvent.

The `PlayerInteractListener#restartCourse()` method (when right-clicking the restart tool) could be run as above, but I just ran the joinCourse() method from with restartCourse() as a task 1 tick later. It might look clearer what was happening if both tasks were initiated in the same method.


I've just noticed I changed `event.getHand() != EquipmentSlot.HAND` to `!event.getHand()`.equals`(EquipmentSlot.HAND)` when debugging - I can change that back if you want.
