### PR TITLE
Remove course selection from players.yml when running [done|ready|deselect|finish] command 

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/commands/ParkourAutoTabCompleter.java
+++ b/src/main/java/io/github/a5h73y/parkour/commands/ParkourAutoTabCompleter.java
@@ -34,7 +34,7 @@ public class ParkourAutoTabCompleter extends AbstractPluginReceiver implements T
             "sql", "cache", "reload");
 
     private static final List<String> ADMIN_COURSE_COMMANDS = Arrays.asList(
-            "checkpoint", "ready", "setstart", "setcourse", "setautostart", "select", "done", "link", "linkkit",
+            "checkpoint", "ready", "setstart", "setcourse", "setautostart", "select", "deselect", "done", "link", "linkkit",
             "addjoinitem", "rewardonce", "rewardlevel", "rewardleveladd", "rewardrank", "rewarddelay", "rewardparkoins",
             "setmode", "createkit", "editkit", "validatekit", "checkpointprize");
 
@@ -56,7 +56,7 @@ public class ParkourAutoTabCompleter extends AbstractPluginReceiver implements T
     private static final List<String> ECONOMY_COMMANDS = Arrays.asList(
             "info", "recreate", "setprize", "setfee");
 
-    private static final List<String> LINK_COMMANDS = Arrays.asList("course", "lobby");
+    private static final List<String> LINK_COMMANDS = Arrays.asList("course", "lobby", "reset");
 
     public ParkourAutoTabCompleter(Parkour parkour) {
         super(parkour);

--- a/src/main/java/io/github/a5h73y/parkour/commands/ParkourCommands.java
+++ b/src/main/java/io/github/a5h73y/parkour/commands/ParkourCommands.java
@@ -262,7 +262,11 @@ public class ParkourCommands extends AbstractPluginReceiver implements CommandEx
                 break;
 
             case "link":
-                if (!ValidationUtils.validateArgs(player, args, 3, 4)) {
+                if (!ValidationUtils.validateArgs(player, args, 2, 3)) {
+                    return false;
+
+                } else if (!PlayerInfo.hasSelectedValidCourse(player)) {
+                    TranslationUtils.sendTranslation("Error.Selected", player);
                     return false;
 
                 } else if (!PermissionUtils.hasPermissionOrCourseOwnership(

--- a/src/main/java/io/github/a5h73y/parkour/type/course/CourseManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/course/CourseManager.java
@@ -334,6 +334,7 @@ public class CourseManager extends AbstractPluginReceiver {
     public void deselectCourse(Player player) {
         if (PlayerInfo.hasSelectedValidCourse(player)) {
             PlayerInfo.resetSelected(player);
+            PlayerInfo.persistChanges();
             player.sendMessage(Parkour.getPrefix() + "Finished editing.");
 
         } else {
@@ -690,6 +691,7 @@ public class CourseManager extends AbstractPluginReceiver {
 
         if (ready) {
             PlayerInfo.resetSelected(player);
+            PlayerInfo.persistChanges();
         }
 
         TranslationUtils.sendPropertySet(player, "Ready Status", courseName, String.valueOf(ready));

--- a/src/main/java/io/github/a5h73y/parkour/type/course/CourseManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/course/CourseManager.java
@@ -334,7 +334,6 @@ public class CourseManager extends AbstractPluginReceiver {
     public void deselectCourse(Player player) {
         if (PlayerInfo.hasSelectedValidCourse(player)) {
             PlayerInfo.resetSelected(player);
-            PlayerInfo.persistChanges();
             player.sendMessage(Parkour.getPrefix() + "Finished editing.");
 
         } else {
@@ -691,7 +690,6 @@ public class CourseManager extends AbstractPluginReceiver {
 
         if (ready) {
             PlayerInfo.resetSelected(player);
-            PlayerInfo.persistChanges();
         }
 
         TranslationUtils.sendPropertySet(player, "Ready Status", courseName, String.valueOf(ready));

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerInfo.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerInfo.java
@@ -57,6 +57,7 @@ public class PlayerInfo {
      */
     public static void resetSelected(OfflinePlayer player) {
         getPlayersConfig().set(player.getUniqueId() + ".Selected", null);
+        persistChanges();
     }
 
     /**


### PR DESCRIPTION
The `ready` and `deselect` commands were not saving the config after removing the selected course from the file, so persistChanges() called after setting the selection to null.

Add check to `/pa link` that player has an active selection and add the `pa link reset` option in tab complete.

Add `deselect` command to tab complete.