### PR TITLE
fix scoreboard npe on joining linked course

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/other/AbstractPluginReceiver.java
+++ b/src/main/java/io/github/a5h73y/parkour/other/AbstractPluginReceiver.java
@@ -3,7 +3,7 @@ package io.github.a5h73y.parkour.other;
 import io.github.a5h73y.parkour.Parkour;
 
 /**
- * Ensure the concrete class receives an instance of the Carz plugin.
+ * Ensure the concrete class receives an instance of the Parkour plugin.
  */
 public abstract class AbstractPluginReceiver {
 

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -615,6 +615,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 			restoreHealth(player);
 			loadInventory(player);
 			rewardPrize(player, courseName);
+			parkour.getScoreboardManager().removeScoreboard(player);
 			if (teleportAway) {
 				teleportCourseCompletion(player, courseName);
 			}
@@ -623,6 +624,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 				restoreHealth(player);
 				loadInventory(player);
 				rewardPrize(player, courseName);
+				parkour.getScoreboardManager().removeScoreboard(player);
 				if (teleportAway) {
 					teleportCourseCompletion(player, courseName);
 				}
@@ -638,7 +640,6 @@ public class PlayerManager extends AbstractPluginReceiver {
 		PlayerInfo.persistChanges();
 
 		forceVisible(player);
-		parkour.getScoreboardManager().removeScoreboard(player);
 		deleteParkourSession(player);
 		Bukkit.getServer().getPluginManager().callEvent(new PlayerFinishCourseEvent(player, courseName));
 	}


### PR DESCRIPTION
The previous scoreboard should be removed before player joins a linked course. If `TeleportDelay` is 0 you get an npe when joining the linked course.

The reason I've put the `removeScoreboard` immediately before the teleport is so that the scoreboard stays on the screen until the teleport happens. It could go before the `if (delay <= 0)` check, but the scoreboard then disappears instantly the player hits the finish block with no time to compare his time against the best time.