### PR TITLE
fix for PlayerInteractEvent firing twice with restart tool

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/listener/PlayerInteractListener.java
+++ b/src/main/java/io/github/a5h73y/parkour/listener/PlayerInteractListener.java
@@ -82,7 +82,7 @@ public class PlayerInteractListener extends AbstractPluginReceiver implements Li
         } else if (materialInHand == parkour.getConfig().getRestartTool()) {
             if (parkour.getPlayerManager().delayPlayer(player, 1, false)) {
                 event.setCancelled(true);
-                parkour.getPlayerManager().restartCourse(player);
+                Bukkit.getScheduler().runTask(parkour, () -> parkour.getPlayerManager().restartCourse(player));
             }
         }
     }

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -659,7 +659,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 		Course course = getParkourSession(player).getCourse();
 		TranslationUtils.sendTranslation("Parkour.Restarting", player);
 		leaveCourse(player, true);
-		Bukkit.getScheduler().runTask(parkour, () -> joinCourse(player, course, true));
+		joinCourse(player, course, true);
 	}
 
 	/**


### PR DESCRIPTION
This makes the restart tool the same as the back-to-last-checkpoint tool by running the restartCourse() method 1 tick later. Testing it, the event correctly fires once for each hand.