### PR TITLE
add seconds to reward delay message

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/other/Validation.java
+++ b/src/main/java/io/github/a5h73y/parkour/other/Validation.java
@@ -15,11 +15,11 @@ import io.github.a5h73y.parkour.utility.TranslationUtils;
 import io.github.a5h73y.parkour.utility.ValidationUtils;
 import java.util.ArrayList;
 import java.util.List;
-import jdk.internal.jline.internal.Nullable;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
 public class Validation {
 

--- a/src/main/java/io/github/a5h73y/parkour/utility/DateTimeUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utility/DateTimeUtils.java
@@ -87,15 +87,26 @@ public class DateTimeUtils {
 		}
 
 		if (time.getDays() > 0) {
-			totalTime.append(1);
-			totalTime.append(" day, ");
+			totalTime.append("1 day, ");
 		}
-		if (time.getHours() > 0) {
+		if (time.getHours() > 1) {
 			totalTime.append(time.getHours());
 			totalTime.append(" hours, ");
+		} else if (time.getHours() > 0) {
+			totalTime.append("1 hour, ");
 		}
-		totalTime.append(time.getMinutes());
-		totalTime.append(" minutes");
+		if (time.getMinutes() > 1) {
+			totalTime.append(time.getMinutes());
+			totalTime.append(" minutes, ");
+		} else if (time.getMinutes() > 0) {
+			totalTime.append("1 minute, ");
+		}
+		if (time.getSeconds() > 1) {
+			totalTime.append(time.getSeconds());
+			totalTime.append(" seconds");
+		} else if (time.getSeconds() > 0) {
+			totalTime.append("1 second");
+		}
 		return totalTime.toString();
 	}
 

--- a/src/main/java/io/github/a5h73y/parkour/utility/DateTimeUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utility/DateTimeUtils.java
@@ -6,6 +6,7 @@ import io.github.a5h73y.parkour.type.player.PlayerInfo;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.StringJoiner;
 
 import org.bukkit.OfflinePlayer;
 
@@ -78,35 +79,32 @@ public class DateTimeUtils {
 
 	public static String displayTimeRemaining(long millis) {
 		MillisecondConverter time = new MillisecondConverter(millis);
-		StringBuilder totalTime = new StringBuilder();
+		StringJoiner totalTime = new StringJoiner(", ");
 
 		if (time.getDays() > 1) {
-			totalTime.append(time.getDays());
-			totalTime.append(" days"); //TODO translate
+			totalTime.add(time.getDays() + " days"); //TODO translate
 			return totalTime.toString();
 		}
 
 		if (time.getDays() > 0) {
-			totalTime.append("1 day, ");
+			totalTime.add("1 day");
 		}
 		if (time.getHours() > 1) {
-			totalTime.append(time.getHours());
-			totalTime.append(" hours, ");
+			totalTime.add(time.getHours() + " hours");
 		} else if (time.getHours() > 0) {
-			totalTime.append("1 hour, ");
+			totalTime.add("1 hour");
 		}
 		if (time.getMinutes() > 1) {
-			totalTime.append(time.getMinutes());
-			totalTime.append(" minutes, ");
+			totalTime.add(time.getMinutes() + " minutes");
 		} else if (time.getMinutes() > 0) {
-			totalTime.append("1 minute, ");
+			totalTime.add("1 minute");
 		}
 		if (time.getSeconds() > 1) {
-			totalTime.append(time.getSeconds());
-			totalTime.append(" seconds");
+			totalTime.add(time.getSeconds() + " seconds");
 		} else if (time.getSeconds() > 0) {
-			totalTime.append("1 second");
+			totalTime.add("1 second");
 		}
+
 		return totalTime.toString();
 	}
 

--- a/src/main/java/io/github/a5h73y/parkour/utility/PluginUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utility/PluginUtils.java
@@ -15,7 +15,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -192,13 +191,6 @@ public class PluginUtils {
 
     public static boolean doesGameModeExist(String gameMode) {
         return getGameMode(gameMode) != null;
-    }
-
-    public static void addWhitelistedCommand(String command) {
-        List<String> commands = Parkour.getDefaultConfig().getWhitelistedCommands();
-        commands.add(command);
-        Parkour.getDefaultConfig().set("OnCourse.EnforceParkourCommands.Whitelist", commands);
-        Parkour.getDefaultConfig().save();
     }
 
     /**


### PR DESCRIPTION
Changed the reward delay message to avoid incorrect  grammar, e.g. "1 hours, 1 minutes remaining".
Also added seconds to the display".

Possibly fixed incorrect import in Validation.java? 

The addWhitelistedCommand method in PluginUtils seems to be redundant and is superceded by the method in DefaultConfig.java.
