### PR TITLE
add translations for time units

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/StringsConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/StringsConfig.java
@@ -192,6 +192,14 @@ public class StringsConfig extends ParkourConfiguration {
 
 		this.addDefault("Display.TimeFormat", "HH:mm:ss:MMM");
 		this.addDefault("Display.DateFormat", "dd/MM/yyyy");
+		this.addDefault("Display.Day", "day");
+		this.addDefault("Display.Days", "days");
+		this.addDefault("Display.Hour", "hour");
+		this.addDefault("Display.Hours", "hours");
+		this.addDefault("Display.Minute", "minute");
+		this.addDefault("Display.Minutes", "minutes");
+		this.addDefault("Display.Second", "second");
+		this.addDefault("Display.Seconds", "seconds");
 
 		this.options().copyDefaults(true);
 	}

--- a/src/main/java/io/github/a5h73y/parkour/utility/DateTimeUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utility/DateTimeUtils.java
@@ -82,27 +82,27 @@ public class DateTimeUtils {
 		StringJoiner totalTime = new StringJoiner(", ");
 
 		if (time.getDays() > 1) {
-			totalTime.add(time.getDays() + " days"); //TODO translate
+			totalTime.add(time.getDays() + " " + TranslationUtils.getTranslation("Display.Days", false));
 			return totalTime.toString();
 		}
 
 		if (time.getDays() > 0) {
-			totalTime.add("1 day");
+			totalTime.add("1 " + TranslationUtils.getTranslation("Display.Day", false));
 		}
 		if (time.getHours() > 1) {
-			totalTime.add(time.getHours() + " hours");
+			totalTime.add(time.getHours() + " " + TranslationUtils.getTranslation("Display.Hours", false));
 		} else if (time.getHours() > 0) {
-			totalTime.add("1 hour");
+			totalTime.add("1 " + TranslationUtils.getTranslation("Display.Hour", false));
 		}
 		if (time.getMinutes() > 1) {
-			totalTime.add(time.getMinutes() + " minutes");
+			totalTime.add(time.getMinutes() + " " + TranslationUtils.getTranslation("Display.Minutes", false));
 		} else if (time.getMinutes() > 0) {
-			totalTime.add("1 minute");
+			totalTime.add("1 " + TranslationUtils.getTranslation("Display.Minute", false));
 		}
 		if (time.getSeconds() > 1) {
-			totalTime.add(time.getSeconds() + " seconds");
+			totalTime.add(time.getSeconds() + " " + TranslationUtils.getTranslation("Display.Seconds", false));
 		} else if (time.getSeconds() > 0) {
-			totalTime.add("1 second");
+			totalTime.add("1 " + TranslationUtils.getTranslation("Display.Second", false));
 		}
 
 		return totalTime.toString();


### PR DESCRIPTION
This works ok - the singular/plural is a bit annoying though. 

Another way avoid that altogether would be to display it as:

`1d 2h 10m 45s`

then have a translation for 'd', 'h', 'm' and 's'.