### PR TITLE
add xmaterial purpur slab to validCheckpointMaterials to avoid exception

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/utility/MaterialUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utility/MaterialUtils.java
@@ -13,6 +13,7 @@ import static com.cryptomorin.xseries.XMaterial.OAK_SLAB;
 import static com.cryptomorin.xseries.XMaterial.PETRIFIED_OAK_SLAB;
 import static com.cryptomorin.xseries.XMaterial.PRISMARINE_BRICK_SLAB;
 import static com.cryptomorin.xseries.XMaterial.PRISMARINE_SLAB;
+import static com.cryptomorin.xseries.XMaterial.PURPUR_SLAB;
 import static com.cryptomorin.xseries.XMaterial.QUARTZ_SLAB;
 import static com.cryptomorin.xseries.XMaterial.RED_SANDSTONE_SLAB;
 import static com.cryptomorin.xseries.XMaterial.SANDSTONE_SLAB;
@@ -237,6 +238,7 @@ public class MaterialUtils {
 					PETRIFIED_OAK_SLAB.parseMaterial(),
 					PRISMARINE_BRICK_SLAB.parseMaterial(),
 					PRISMARINE_SLAB.parseMaterial(),
+					PURPUR_SLAB.parseMaterial(),
 					QUARTZ_SLAB.parseMaterial(),
 					RED_SANDSTONE_SLAB.parseMaterial(),
 					SANDSTONE_SLAB.parseMaterial(),
@@ -244,9 +246,6 @@ public class MaterialUtils {
 					STONE_BRICK_SLAB.parseMaterial(),
 					STONE_SLAB.parseMaterial());
 
-			if (!Bukkit.getBukkitVersion().contains("1.8")) {
-				validCheckpointMaterials.add(Material.PURPUR_SLAB);
-			}
 		}
 
 		return validCheckpointMaterials;


### PR DESCRIPTION
Running `/pa checkpoint` causes UnsupportedOperationException if _EnforceSafeCheckpoints = true_. Caused by adding PURPUR_SLAB to the immutable list of valid materials.

I think that piece of code for Minecraft 1.8 pre-dates using XMaterial, so I don't think there's any reason not to include PURPUR_SLAB with the other materials when creating the list. 

Tested on 1.8.8 and 1.16.4 without any issues.