### PR TITLE
placeholder identifier must be lowercase

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
+++ b/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
@@ -42,7 +42,7 @@ public class ParkourPlaceholders extends PlaceholderExpansion {
     @NotNull
     @Override
     public String getIdentifier() {
-        return parkour.getName();
+        return parkour.getName().toLowerCase();
     }
 
     @NotNull


### PR DESCRIPTION
This fixes the issue with ChatControl / ChatControlPro not populating the Parkour placeholders.