### PR TITLE
Don't send title if it's empty

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/plugin/BountifulApi.java
+++ b/src/main/java/io/github/a5h73y/parkour/plugin/BountifulApi.java
@@ -88,7 +88,11 @@ public class BountifulApi extends PluginWrapper {
 				TranslationUtils.sendMessage(player, title);
 			}
 		} else {
-			TranslationUtils.sendMessage(player, title);
+			if (title.isEmpty()) {
+				TranslationUtils.sendMessage(player, subTitle);
+			} else {
+				TranslationUtils.sendMessage(player, title);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue where parkour sends "empty" messages to players. This happens for all cases where `sendSubTitle` is used, and one has disabled titles in the config.