### PR TITLE
use player hitbox to detect blocks beneath player

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/listener/PlayerMoveListener.java
+++ b/src/main/java/io/github/a5h73y/parkour/listener/PlayerMoveListener.java
@@ -65,86 +65,86 @@ public class PlayerMoveListener extends AbstractPluginReceiver implements Listen
             return;
         }
 
-        Material belowMaterial = player.getLocation().getBlock().getRelative(BlockFace.DOWN).getType();
-
-        // if player is on half-block or jumping, get actual location.
-        if (!parkour.getConfig().isLegacyGroundDetection()
-                && (!XBlock.isAir(player.getLocation().getBlock().getType()) || !player.isOnGround())) {
-            belowMaterial = player.getLocation().getBlock().getType();
-        }
-
-        ParkourKit kit = session.getCourse().getParkourKit();
-
-        if (belowMaterial.equals(Material.SPONGE)) {
-            player.setFallDistance(0);
-        }
-
-        ParkourKitAction kitAction = kit.getAction(belowMaterial);
-
-        if (kitAction != null) {
-            switch (kitAction.getActionType()) {
-                case FINISH:
-                    parkour.getPlayerManager().finishCourse(player);
-                    break;
-
-                case DEATH:
-                    parkour.getPlayerManager().playerDie(player);
-                    break;
-
-                case LAUNCH:
-                    player.setVelocity(new Vector(0, kitAction.getStrength(), 0));
-                    break;
-
-                case BOUNCE:
-                    if (!player.hasPotionEffect(PotionEffectType.JUMP)) {
-                        PlayerUtils.applyPotionEffect(PotionEffectType.JUMP, kitAction.getDuration(),
-                                (int) kitAction.getStrength(), player);
-                    }
-                    break;
-
-                case SPEED:
-                    if (!player.hasPotionEffect(PotionEffectType.SPEED)) {
-                        PlayerUtils.applyPotionEffect(PotionEffectType.SPEED, kitAction.getDuration(),
-                                (int) kitAction.getStrength(), player);
-                    }
-                    break;
-
-                case NORUN:
-                    player.setSprinting(false);
-                    break;
-
-                case NOPOTION:
-                    PlayerUtils.removeAllPotionEffects(player);
-                    player.setFireTicks(0);
-                    break;
-
-                default:
-                    break;
+        for (Material belowMaterial : MaterialUtils.getMaterialUnderPlayer(player.getLocation())) {
+            // if player is on half-block or jumping, get actual location.
+            if (!parkour.getConfig().isLegacyGroundDetection()
+                    && (!XBlock.isAir(player.getLocation().getBlock().getType()) || !player.isOnGround())) {
+                belowMaterial = player.getLocation().getBlock().getType();
             }
-        } else {
-            for (BlockFace blockFace : BLOCK_FACES) {
-                Material material = player.getLocation().getBlock().getRelative(blockFace).getType();
-                kitAction = kit.getAction(material);
 
-                if (kitAction != null) {
-                    switch (kitAction.getActionType()) {
-                        case CLIMB:
-                            if (!player.isSneaking()) {
-                                player.setVelocity(new Vector(0, kitAction.getStrength(), 0));
-                            }
-                            break;
+            ParkourKit kit = session.getCourse().getParkourKit();
 
-                        case REPULSE:
-                            double strength = kitAction.getStrength();
-                            double x = blockFace == BlockFace.NORTH || blockFace == BlockFace.SOUTH ? 0
-                                    : blockFace == BlockFace.EAST ? -strength : strength;
-                            double z = blockFace == BlockFace.EAST || blockFace == BlockFace.WEST ? 0
-                                    : blockFace == BlockFace.NORTH ? strength : -strength;
+            if (belowMaterial.equals(Material.SPONGE)) {
+                player.setFallDistance(0);
+            }
 
-                            player.setVelocity(new Vector(x, 0.1, z));
-                            break;
+            ParkourKitAction kitAction = kit.getAction(belowMaterial);
 
-                        default:
+            if (kitAction != null) {
+                switch (kitAction.getActionType()) {
+                    case FINISH:
+                        parkour.getPlayerManager().finishCourse(player);
+                        break;
+
+                    case DEATH:
+                        parkour.getPlayerManager().playerDie(player);
+                        break;
+
+                    case LAUNCH:
+                        player.setVelocity(new Vector(0, kitAction.getStrength(), 0));
+                        break;
+
+                    case BOUNCE:
+                        if (!player.hasPotionEffect(PotionEffectType.JUMP)) {
+                            PlayerUtils.applyPotionEffect(PotionEffectType.JUMP, kitAction.getDuration(),
+                                    (int) kitAction.getStrength(), player);
+                        }
+                        break;
+
+                    case SPEED:
+                        if (!player.hasPotionEffect(PotionEffectType.SPEED)) {
+                            PlayerUtils.applyPotionEffect(PotionEffectType.SPEED, kitAction.getDuration(),
+                                    (int) kitAction.getStrength(), player);
+                        }
+                        break;
+
+                    case NORUN:
+                        player.setSprinting(false);
+                        break;
+
+                    case NOPOTION:
+                        PlayerUtils.removeAllPotionEffects(player);
+                        player.setFireTicks(0);
+                        break;
+
+                    default:
+                        break;
+                }
+            } else {
+                for (BlockFace blockFace : BLOCK_FACES) {
+                    Material material = player.getLocation().getBlock().getRelative(blockFace).getType();
+                    kitAction = kit.getAction(material);
+
+                    if (kitAction != null) {
+                        switch (kitAction.getActionType()) {
+                            case CLIMB:
+                                if (!player.isSneaking()) {
+                                    player.setVelocity(new Vector(0, kitAction.getStrength(), 0));
+                                }
+                                break;
+
+                            case REPULSE:
+                                double strength = kitAction.getStrength();
+                                double x = blockFace == BlockFace.NORTH || blockFace == BlockFace.SOUTH ? 0
+                                        : blockFace == BlockFace.EAST ? -strength : strength;
+                                double z = blockFace == BlockFace.EAST || blockFace == BlockFace.WEST ? 0
+                                        : blockFace == BlockFace.NORTH ? strength : -strength;
+
+                                player.setVelocity(new Vector(x, 0.1, z));
+                                break;
+
+                            default:
+                        }
                     }
                 }
             }

--- a/src/main/java/io/github/a5h73y/parkour/utility/MaterialUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utility/MaterialUtils.java
@@ -25,17 +25,19 @@ import static com.cryptomorin.xseries.XMaterial.matchXMaterial;
 import com.cryptomorin.xseries.XMaterial;
 import io.github.a5h73y.parkour.Parkour;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.material.Stairs;
+import org.bukkit.util.NumberConversions;
 
 /**
  * Material Utility methods.
@@ -249,5 +251,39 @@ public class MaterialUtils {
 		}
 
 		return validCheckpointMaterials;
+	}
+
+	private static double PLAYER_BOUNDINGBOX = 0.3;
+
+	/**
+	 * Get the Materials under the player's feet.
+	 * @param location Player's location
+	 * @return Set of up to 4 Materials
+	 */
+	public static HashSet<Material> getMaterialUnderPlayer(Location location) {
+		HashSet<Material> materials = new HashSet<>();
+		int y = location.getBlockY() - 1;
+		World world = location.getWorld();
+		Block b11 = world.getBlockAt(NumberConversions.floor(location.getX() + PLAYER_BOUNDINGBOX), y,
+				NumberConversions.floor(location.getZ() - PLAYER_BOUNDINGBOX));
+		if (b11.getType() != Material.AIR) {
+			materials.add(b11.getType());
+		}
+		Block b12 = world.getBlockAt(NumberConversions.floor(location.getX() - PLAYER_BOUNDINGBOX), y,
+				NumberConversions.floor(location.getZ() + PLAYER_BOUNDINGBOX));
+		if (b12.getType() != Material.AIR) {
+			materials.add(b12.getType());
+		}
+		Block b21 = world.getBlockAt(NumberConversions.floor(location.getX() + PLAYER_BOUNDINGBOX), y,
+				NumberConversions.floor(location.getZ() + PLAYER_BOUNDINGBOX));
+		if (b21.getType() != Material.AIR) {
+			materials.add(b21.getType());
+		}
+		Block b22 = world.getBlockAt(NumberConversions.floor(location.getX() - PLAYER_BOUNDINGBOX), y,
+				NumberConversions.floor(location.getZ() - PLAYER_BOUNDINGBOX));
+		if (b22.getType() != Material.AIR) {
+			materials.add(b22.getType());
+		}
+		return materials;
 	}
 }


### PR DESCRIPTION
This is a potential fix for #252  - Death block can be bypassed if next to air.

Instead of only checking the block directly beneath the centre of the player, it will check all the blocks within 0.3 of the player. This can be up to 4 blocks if the player is standing on or near the boundary of 4 blocks.

This fixes the issue where a player can be on the edge of a death block (or any other block in a parkour kit) and is being supported by the block, but it doesn't trigger the 'action' associated with the block, e.g. standing on finish block but Parkour is not 'seeing' the block
![finish_block](https://user-images.githubusercontent.com/6975392/103759204-4193ce00-500b-11eb-9e70-ec65ebcf1762.PNG)

A possible downside is that the actions will trigger when the tiniest part of the player touches the block, so for example a player will seem to finish the course before being fully on the finish block.

When reducing the 0.3 to make it less 'sensitive' the issue in #252 returns.