### PR TITLE
add placeholder to return player's best times in milliseconds

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
+++ b/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
@@ -342,6 +342,9 @@ public class ParkourPlaceholders extends PlaceholderExpansion {
                 case "time":
                     return DateTimeUtils.displayCurrentTime(result.getTime());
 
+                case "milliseconds":
+                    return String.valueOf(result.getTime());
+
                 case "deaths":
                     return String.valueOf(result.getDeaths());
 


### PR DESCRIPTION
Adding the player placeholder below should allow the plugin LeaderHeads to rank players based on their times in milliseconds. I don't believe it can currently do this as our 'time' placeholders return a formatted string rather than a numeric value.
```
%parkour_player_personal_best_{course}_milliseconds%
%parkour_course_record_{course}_milliseconds%
```
