### PR TITLE
prevent npe if scoreboard is removed by another plugin

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/manager/ScoreboardManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/manager/ScoreboardManager.java
@@ -106,7 +106,7 @@ public class ScoreboardManager extends AbstractPluginReceiver {
     public void updateScoreboardTimer(Player player, String liveTime) {
         Scoreboard board = player.getScoreboard();
 
-        if (!enabled || !scoreboardDetails.get(LIVE_TIMER).isEnabled()) {
+        if (!enabled || !scoreboardDetails.get(LIVE_TIMER).isEnabled() || board.getTeam(LIVE_TIMER) == null) {
             return;
         }
 
@@ -122,7 +122,7 @@ public class ScoreboardManager extends AbstractPluginReceiver {
     public void updateScoreboardDeaths(Player player, int deaths) {
         Scoreboard board = player.getScoreboard();
 
-        if (!enabled || !scoreboardDetails.get(CURRENT_DEATHS).isEnabled()) {
+        if (!enabled || !scoreboardDetails.get(CURRENT_DEATHS).isEnabled() || board.getTeam(CURRENT_DEATHS) == null) {
             return;
         }
 
@@ -138,7 +138,7 @@ public class ScoreboardManager extends AbstractPluginReceiver {
     public void updateScoreboardCheckpoints(Player player, ParkourSession session) {
         Scoreboard board = player.getScoreboard();
 
-        if (!enabled || !scoreboardDetails.get(CHECKPOINTS).isEnabled()) {
+        if (!enabled || !scoreboardDetails.get(CHECKPOINTS).isEnabled() || board.getTeam(CHECKPOINTS) == null) {
             return;
         }
 


### PR DESCRIPTION
This PR completes the fix for #264 by preventing a null pointer exception when Parkour attempts to update the dynamic entries in the scoreboard (LIVE_TIMER, etc) if the scoreboard has been removed by another plugin. The static parts of the scoreboard (COURSE_NAME, etc) are not affected as they are only updated once when the scoreboard is created.

The bug in McMMO which produced #264 has been fixed in release 2.1.173 of McMMO:
`Fixed a bug where scoreboards were torn down inappropriately when moving to or from blacklisted worlds`.
