### PR TITLE
Add 'remaining deaths' placeholder and as a scoreboard option

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
+++ b/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
@@ -277,6 +277,12 @@ public class ParkourPlaceholders extends PlaceholderExpansion {
                         }
                         return getPersonalCourseRecord(player, session.getCourseName(), arguments[4]);
 
+                    case "remaining":
+                        if (arguments.length != 4 && !arguments[3].equals("deaths")) {
+                            return INVALID_SYNTAX;
+                        }
+                        return String.valueOf(parkour.getPlayerManager().getRemainingLives(session));
+
                     default:
                         return INVALID_SYNTAX;
                 }

--- a/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
+++ b/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
@@ -281,7 +281,7 @@ public class ParkourPlaceholders extends PlaceholderExpansion {
                         if (arguments.length != 4 && !arguments[3].equals("deaths")) {
                             return INVALID_SYNTAX;
                         }
-                        return String.valueOf(parkour.getPlayerManager().getRemainingLives(session));
+                        return String.valueOf(parkour.getPlayerManager().getRemainingDeaths(session));
 
                     default:
                         return INVALID_SYNTAX;

--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
@@ -140,6 +140,8 @@ public class DefaultConfig extends ParkourConfiguration {
 		this.addDefault("Scoreboard.Checkpoints.Sequence", 6);
 		this.addDefault("Scoreboard.LiveTimer.Enabled", true);
 		this.addDefault("Scoreboard.LiveTimer.Sequence", 7);
+		this.addDefault("Scoreboard.RemainingDeaths.Enabled", false);
+		this.addDefault("Scoreboard.RemainingDeaths.Sequence", 8);
 
 		this.addDefault("Sounds.Enabled", true);
 		this.addDefault("Sounds.SecondIncrement.Enabled", true);

--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/StringsConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/StringsConfig.java
@@ -160,6 +160,7 @@ public class StringsConfig extends ParkourConfiguration {
 		this.addDefault("Scoreboard.BestTimeEverNameTitle", "Best Player:");
 		this.addDefault("Scoreboard.MyBestTimeTitle", "My Best Time:");
 		this.addDefault("Scoreboard.CurrentDeathsTitle", "Current Deaths:");
+		this.addDefault("Scoreboard.RemainingDeathsTitle", "Remaining Deaths:");
 		this.addDefault("Scoreboard.CheckpointsTitle", "Checkpoints:");
 		this.addDefault("Scoreboard.LiveTimerTitle", "Current Time:");
 		this.addDefault("Scoreboard.TimeRemainingTitle", "Time Remaining:");

--- a/src/main/java/io/github/a5h73y/parkour/manager/ScoreboardManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/manager/ScoreboardManager.java
@@ -191,7 +191,7 @@ public class ScoreboardManager extends AbstractPluginReceiver {
 
         // update the dynamic results with their session (could be pre-populated)
         updateScoreboardCheckpoints(player, playerScoreboard.getSession());
-        updateScoreboardDeaths(player, playerScoreboard.getSession().getDeaths(), parkour.getPlayerManager().getRemainingLives(session));
+        updateScoreboardDeaths(player, playerScoreboard.getSession().getDeaths(), parkour.getPlayerManager().getRemainingDeaths(session));
 
         return board;
     }

--- a/src/main/java/io/github/a5h73y/parkour/manager/ScoreboardManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/manager/ScoreboardManager.java
@@ -36,6 +36,7 @@ public class ScoreboardManager extends AbstractPluginReceiver {
     private static final String BEST_TIME_EVER_NAME = ChatColor.BLUE.toString();
     private static final String MY_BEST_TIME_EVER = ChatColor.DARK_AQUA.toString();
     private static final String CURRENT_DEATHS = ChatColor.DARK_GREEN.toString();
+    private static final String REMAINING_DEATHS = ChatColor.DARK_GRAY.toString();
     private static final String CHECKPOINTS = ChatColor.DARK_RED.toString();
     private static final String LIVE_TIMER = ChatColor.DARK_BLUE.toString();
 
@@ -64,6 +65,7 @@ public class ScoreboardManager extends AbstractPluginReceiver {
         scoreboardDetails.put(BEST_TIME_EVER_NAME, generateScoreboard("BestTimeEverName"));
         scoreboardDetails.put(MY_BEST_TIME_EVER, generateScoreboard("MyBestTime"));
         scoreboardDetails.put(CURRENT_DEATHS, generateScoreboard("CurrentDeaths"));
+        scoreboardDetails.put(REMAINING_DEATHS, generateScoreboard("RemainingDeaths"));
         scoreboardDetails.put(CHECKPOINTS, generateScoreboard("Checkpoints"));
         scoreboardDetails.put(LIVE_TIMER, generateScoreboard("LiveTimer"));
 
@@ -118,15 +120,20 @@ public class ScoreboardManager extends AbstractPluginReceiver {
      *
      * @param player player
      * @param deaths death amount
+     * @param deaths remaining deaths
      */
-    public void updateScoreboardDeaths(Player player, int deaths) {
+    public void updateScoreboardDeaths(Player player, int deaths, int remainingDeaths) {
         Scoreboard board = player.getScoreboard();
 
-        if (!enabled || !scoreboardDetails.get(CURRENT_DEATHS).isEnabled() || board.getTeam(CURRENT_DEATHS) == null) {
+        if (!enabled) {
             return;
         }
-
-        board.getTeam(CURRENT_DEATHS).setPrefix(convertText(String.valueOf(deaths)));
+        if (scoreboardDetails.get(CURRENT_DEATHS).isEnabled() && board.getTeam(CURRENT_DEATHS) != null) {
+            board.getTeam(CURRENT_DEATHS).setPrefix(convertText(String.valueOf(deaths)));
+        }
+        if (scoreboardDetails.get(REMAINING_DEATHS).isEnabled() && board.getTeam(REMAINING_DEATHS) != null) {
+            board.getTeam(REMAINING_DEATHS).setPrefix(convertText(String.valueOf(remainingDeaths)));
+        }
     }
 
     /**
@@ -184,7 +191,7 @@ public class ScoreboardManager extends AbstractPluginReceiver {
 
         // update the dynamic results with their session (could be pre-populated)
         updateScoreboardCheckpoints(player, playerScoreboard.getSession());
-        updateScoreboardDeaths(player, playerScoreboard.getSession().getDeaths());
+        updateScoreboardDeaths(player, playerScoreboard.getSession().getDeaths(), parkour.getPlayerManager().getRemainingLives(session));
 
         return board;
     }

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -441,7 +441,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 			return;
 		}
 
-		parkour.getScoreboardManager().updateScoreboardDeaths(player, session.getDeaths());
+		parkour.getScoreboardManager().updateScoreboardDeaths(player, session.getDeaths(), getRemainingLives(session));
 		parkour.getCourseManager().runEventCommands(player, session.getCourseName(), DEATH);
 
 		// if it's the first checkpoint

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -70,7 +70,6 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -420,11 +419,10 @@ public class PlayerManager extends AbstractPluginReceiver {
 
 		if (session.getCourse().hasMaxDeaths()) {
 			if (session.getCourse().getMaxDeaths() > session.getDeaths()) {
-				int remainingLives = session.getCourse().getMaxDeaths() - session.getDeaths();
 
 				parkour.getBountifulApi().sendSubTitle(player,
 						TranslationUtils.getValueTranslation(
-								"Parkour.LifeCount", String.valueOf(remainingLives), false),
+								"Parkour.LifeCount", String.valueOf(getRemainingLives(session)), false),
 						parkour.getConfig().getBoolean("DisplayTitle.Death"));
 
 			} else {
@@ -472,6 +470,17 @@ public class PlayerManager extends AbstractPluginReceiver {
 
 		preparePlayer(player, parkour.getConfig().getString("OnJoin.SetGameMode"));
 		Bukkit.getServer().getPluginManager().callEvent(new PlayerDeathEvent(player, session.getCourse().getName()));
+	}
+
+	/**
+	 * Get the player's remaining lives.
+	 *
+	 * @param session
+	 * @return number of lives remaining
+	 */
+	public int getRemainingLives(ParkourSession session) {
+		int remainingLives = session.getCourse().getMaxDeaths() - session.getDeaths();
+		return remainingLives > 0 ? remainingLives : 0;
 	}
 
 	/**

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -422,7 +422,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 
 				parkour.getBountifulApi().sendSubTitle(player,
 						TranslationUtils.getValueTranslation(
-								"Parkour.LifeCount", String.valueOf(getRemainingLives(session)), false),
+								"Parkour.LifeCount", String.valueOf(getRemainingDeaths(session)), false),
 						parkour.getConfig().getBoolean("DisplayTitle.Death"));
 
 			} else {
@@ -441,7 +441,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 			return;
 		}
 
-		parkour.getScoreboardManager().updateScoreboardDeaths(player, session.getDeaths(), getRemainingLives(session));
+		parkour.getScoreboardManager().updateScoreboardDeaths(player, session.getDeaths(), getRemainingDeaths(session));
 		parkour.getCourseManager().runEventCommands(player, session.getCourseName(), DEATH);
 
 		// they haven't yet achieved a checkpoint
@@ -473,14 +473,14 @@ public class PlayerManager extends AbstractPluginReceiver {
 	}
 
 	/**
-	 * Get the player's remaining lives.
+	 * Get the player's remaining deaths.
 	 *
 	 * @param session
-	 * @return number of lives remaining
+	 * @return number of deaths remaining
 	 */
-	public int getRemainingLives(ParkourSession session) {
-		int remainingLives = session.getCourse().getMaxDeaths() - session.getDeaths();
-		return remainingLives > 0 ? remainingLives : 0;
+	public int getRemainingDeaths(ParkourSession session) {
+		int remainingDeaths = session.getCourse().getMaxDeaths() - session.getDeaths();
+		return remainingDeaths > 0 ? remainingDeaths : 0;
 	}
 
 	/**


### PR DESCRIPTION
Added placeholder `%parkour_current_course_remaining_deaths%` as discussed, with a `PlayerManager#getRemainingLives` method.

A couple of things:
the term 'remaining lives' and 'remaining deaths' are (maybe) confusing in the code, and
with the extra scoreboard option, the number of lines is > 16 so all the options can't be displayed at the same time (although 'current deaths' and 'deaths remaining' probably wouldn't need to be displayed together), so the new option is defaulted to 'false'.