### PR TITLE
Allow translated message strings to be empty

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -431,7 +431,7 @@ public class PlayerManager extends AbstractPluginReceiver {
 
 			} else {
 				TranslationUtils.sendValueTranslation("Parkour.MaxDeaths",
-						String.valueOf(session.getCourse().getMaxDeaths()));
+						String.valueOf(session.getCourse().getMaxDeaths()), player);
 				leaveCourse(player);
 				return;
 			}

--- a/src/main/java/io/github/a5h73y/parkour/utility/SignUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utility/SignUtils.java
@@ -29,7 +29,7 @@ public class SignUtils {
         signEvent.setLine(1, signType);
         signEvent.setLine(2, "");
         signEvent.setLine(3, "-----");
-        TranslationUtils.sendValueTranslation("Parkour.SignCreated", signType);
+        TranslationUtils.sendValueTranslation("Parkour.SignCreated", signType, player);
     }
 
     /**
@@ -70,7 +70,7 @@ public class SignUtils {
         signEvent.setLine(1, signType);
 
         if (displayMessage) {
-            TranslationUtils.sendValueTranslation("Parkour.SignCreated", signType);
+            TranslationUtils.sendValueTranslation("Parkour.SignCreated", signType, player);
         }
         return true;
     }
@@ -93,7 +93,7 @@ public class SignUtils {
             signEvent.setLine(3, ChatColor.RED + String.valueOf(minimumLevel));
         }
 
-        TranslationUtils.sendValueTranslation("Parkour.SignCreated", "Join");
+        TranslationUtils.sendValueTranslation("Parkour.SignCreated", "Join", player);
     }
 
     /**
@@ -112,7 +112,7 @@ public class SignUtils {
 
         if (signEvent.getLine(2).isEmpty()) {
             signEvent.setLine(3, "");
-            TranslationUtils.sendValueTranslation("Parkour.SignCreated", "Lobby");
+            TranslationUtils.sendValueTranslation("Parkour.SignCreated", "Lobby", player);
 
         } else {
             String lobbyName = signEvent.getLine(2);
@@ -127,7 +127,7 @@ public class SignUtils {
             if (LobbyInfo.hasRequiredLevel(lobbyName)) {
                 signEvent.setLine(3, ChatColor.RED + LobbyInfo.getRequiredLevel(lobbyName).toString());
             }
-            TranslationUtils.sendValueTranslation("Parkour.SignCreated", "Lobby");
+            TranslationUtils.sendValueTranslation("Parkour.SignCreated", "Lobby", player);
         }
     }
 
@@ -148,14 +148,14 @@ public class SignUtils {
 
         if (signEvent.getLine(2).equalsIgnoreCase("heal")) {
             signEvent.setLine(2, "Heal");
-            TranslationUtils.sendValueTranslation("Parkour.SignCreated", "Heal Effect");
+            TranslationUtils.sendValueTranslation("Parkour.SignCreated", "Heal Effect", player);
 
         } else if (signEvent.getLine(2).equalsIgnoreCase("gamemode")) {
             signEvent.setLine(2, "GameMode");
 
             if (PluginUtils.doesGameModeExist(signEvent.getLine(3))) {
                 signEvent.setLine(3, signEvent.getLine(3).toUpperCase());
-                TranslationUtils.sendValueTranslation("Parkour.SignCreated", "GameMode Effect");
+                TranslationUtils.sendValueTranslation("Parkour.SignCreated", "GameMode Effect", player);
 
             } else {
                 signEvent.getBlock().breakNaturally();
@@ -198,7 +198,7 @@ public class SignUtils {
             signEvent.setLine(3, "");
         }
 
-        TranslationUtils.sendValueTranslation("Parkour.SignCreated", "Leaderboard");
+        TranslationUtils.sendValueTranslation("Parkour.SignCreated", "Leaderboard", player);
     }
 
     /**
@@ -218,7 +218,7 @@ public class SignUtils {
             return;
         }
 
-        TranslationUtils.sendValueTranslation("Parkour.SignCreated", "Checkpoint");
+        TranslationUtils.sendValueTranslation("Parkour.SignCreated", "Checkpoint", player);
     }
 
     /**

--- a/src/main/java/io/github/a5h73y/parkour/utility/TranslationUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utility/TranslationUtils.java
@@ -160,9 +160,11 @@ public class TranslationUtils {
 	 */
 	public static void sendValueTranslation(String translationKey, String value, boolean prefix, CommandSender... players) {
 		String translation = getValueTranslation(translationKey, value, prefix);
-		for (CommandSender player : players) {
-			if (player != null) {
-				player.sendMessage(translation);
+		if (!translation.isEmpty()) {
+			for (CommandSender player : players) {
+				if (player != null) {
+					player.sendMessage(translation);
+				}
 			}
 		}
 	}

--- a/src/main/java/io/github/a5h73y/parkour/utility/TranslationUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utility/TranslationUtils.java
@@ -34,7 +34,9 @@ public class TranslationUtils {
 
 		String translated = Parkour.getConfig(ConfigType.STRINGS).getString(translationKey);
 		translated = translated != null ? colour(translated) : "String not found: " + translationKey;
-		return prefix ? Parkour.getPrefix().concat(translated) : translated;
+
+		return (prefix && ValidationUtils.isStringValid(translated))
+				? Parkour.getPrefix().concat(translated) : translated;
 	}
 
 	/**
@@ -120,8 +122,10 @@ public class TranslationUtils {
 	 */
 	public static void sendTranslation(String translationKey, boolean prefix, CommandSender... players) {
 		String translation = getTranslation(translationKey, prefix);
-		for (CommandSender player : players) {
-			player.sendMessage(translation);
+		if (!translation.isEmpty()) {
+			for (CommandSender player : players) {
+				player.sendMessage(translation);
+			}
 		}
 	}
 


### PR DESCRIPTION
Allow 'unwanted' messages to not be sent by setting them to an empty string in strings.yml.
So,
- Don't add the prefix to empty messages.
- Don't send empty messages to player.
