### PR TITLE
check if message is empty in TranslationUtils#sendMessage

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/utility/TranslationUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utility/TranslationUtils.java
@@ -228,7 +228,9 @@ public class TranslationUtils {
 	 * @param message message to send
 	 */
 	public static void sendMessage(CommandSender sender, String message) {
-		sender.sendMessage(Parkour.getPrefix().concat(colour(message)));
+		if (!message.isEmpty()) {
+			sender.sendMessage(Parkour.getPrefix().concat(colour(message)));
+		}
 	}
 
 	/**


### PR DESCRIPTION
The majority of messages going through this method are hard-coded so will not be empty strings, but `Parkour.Die1` is one string that does. 
Checking if the string is not empty before sending will prevent a blank message with prefix being sent to the player if the string is set to '' (empty).