### PR TITLE
handle non-existent kit which can generate an npe

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/listener/PlayerMoveListener.java
+++ b/src/main/java/io/github/a5h73y/parkour/listener/PlayerMoveListener.java
@@ -74,6 +74,9 @@ public class PlayerMoveListener extends AbstractPluginReceiver implements Listen
         }
 
         ParkourKit kit = session.getCourse().getParkourKit();
+        if (kit == null) {
+            return;
+        }
 
         if (belowMaterial.equals(Material.SPONGE)) {
             player.setFallDistance(0);


### PR DESCRIPTION
A non-existent ParkourKit in _courses.yml_ will generate an npe in PlayerMoveListener.
Fixes issue mentioned in #283.