### PR TITLE
fixes issues around 'rewardOnce:true' from #286

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/type/lobby/LobbyInfo.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/lobby/LobbyInfo.java
@@ -3,6 +3,7 @@ package io.github.a5h73y.parkour.type.lobby;
 import io.github.a5h73y.parkour.Parkour;
 import io.github.a5h73y.parkour.configuration.impl.DefaultConfig;
 import io.github.a5h73y.parkour.other.ParkourConstants;
+import java.util.Collections;
 import java.util.Set;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -19,7 +20,9 @@ public class LobbyInfo {
 	 * @return lobby names
 	 */
 	public static Set<String> getAllLobbyNames() {
-		return Parkour.getDefaultConfig().getConfigurationSection("Lobby").getKeys(false);
+		return Parkour.getDefaultConfig().isConfigurationSection("Lobby")
+					? Parkour.getDefaultConfig().getConfigurationSection("Lobby").getKeys(false)
+					: Collections.emptySet();
 	}
 
 	/**

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -1228,6 +1228,9 @@ public class PlayerManager extends AbstractPluginReceiver {
 	 */
 	public void deleteParkourSessions(OfflinePlayer player) {
 		File playersFolder = new File(getParkourSessionsDirectory() + File.separator + player.getUniqueId().toString());
+		if (Files.notExists(playersFolder.toPath())) {
+			return;
+		}
 
 		try (Stream<Path> paths = Files.walk(playersFolder.toPath())) {
 			paths.sorted(Comparator.reverseOrder())

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -558,15 +558,14 @@ public class PlayerManager extends AbstractPluginReceiver {
 			if (teleportAway) {
 				teleportCourseCompletion(player, courseName);
 			}
+			boolean recordTime = isNewRecord(player, session);
+			parkour.getDatabase().insertOrUpdateTime(
+					courseName, player, session.getTimeFinished(), session.getDeaths(), recordTime);
+
+			if (recordTime) {
+				parkour.getCourseManager().runEventCommands(player, session, COURSE_RECORD);
+			}
 		}, delay);
-
-		boolean recordTime = isNewRecord(player, session);
-		parkour.getDatabase().insertOrUpdateTime(
-				courseName, player, session.getTimeFinished(), session.getDeaths(), recordTime);
-
-		if (recordTime) {
-			parkour.getCourseManager().runEventCommands(player, session, COURSE_RECORD);
-		}
 
 		PlayerInfo.setLastCompletedCourse(player, courseName);
 		PlayerInfo.addCompletedCourse(player, courseName);


### PR DESCRIPTION
This addresses the 3 issues mentioned in #286:
1. The rewardPrize() method (and `rewardOnce` check) is run in a scheduler task which means it's possible for the database to be updated with a player's new time before the check is made on whether the player has already completed the course. If this is the case, the check will always return true and no prize will be rewarded. Can be fixed by moving the db update into the scheduler task to ensure it occurs after the rewardPrize() method.

2. If there is no lobby set in the config, e.g. on a new install, the commands `/pa list lobbies` and `/pa lobbies ` (tab complete) will cause an exception when getConfigurationSection() returns null. Can be fixed by checking for the existence of the `Lobby:` configuration section.

3. Resetting a player causes an exception if the session folder doesn't exist. Can be fixed by checking if the folder exists before attempting to delete it.
