### PR TITLE
fix/workaround for sub-titles not displaying on 1.17 servers / add a 'potion' parkour block for parkour kits

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/StringsConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/StringsConfig.java
@@ -108,7 +108,7 @@ public class StringsConfig extends ParkourConfiguration {
 		this.addDefault("Error.UnknownSignCommand", "Unknown sign command!");
 		this.addDefault("Error.UnknownCommand", "Unknown command!");
 		this.addDefault("Error.UnknownPlayer", "Unknown Parkour player!");
-		this.addDefault("Error.UnknownMaterial", "Unknown Material: &4%VALUE%");
+		this.addDefault("Error.UnknownMaterial", "Unknown Material: &4%VALUE%&c");
 		this.addDefault("Error.UnknownPotionEffectType", "Unknown Potion Effect type: &4%VALUE%&c");
 		this.addDefault("Error.UnknownLobby", "%VALUE% lobby does not exist!");
 		this.addDefault("Error.UnknownWorld", "The requested world doesn't exist.");

--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/StringsConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/StringsConfig.java
@@ -109,6 +109,7 @@ public class StringsConfig extends ParkourConfiguration {
 		this.addDefault("Error.UnknownCommand", "Unknown command!");
 		this.addDefault("Error.UnknownPlayer", "Unknown Parkour player!");
 		this.addDefault("Error.UnknownMaterial", "Unknown Material: &4%VALUE%");
+		this.addDefault("Error.UnknownPotionEffectType", "Unknown Potion Effect type: &4%VALUE%&c");
 		this.addDefault("Error.UnknownLobby", "%VALUE% lobby does not exist!");
 		this.addDefault("Error.UnknownWorld", "The requested world doesn't exist.");
 		this.addDefault("Error.UnknownParkourKit", "Unknown ParkourKit.");
@@ -185,6 +186,7 @@ public class StringsConfig extends ParkourConfiguration {
 		this.addDefault("Kit.Death", "&bDeath Block");
 		this.addDefault("Kit.Bounce", "&bBounce Block");
 		this.addDefault("Kit.Repulse", "&bRepulse Block");
+		this.addDefault("Kit.Potion", "&bPotion Block");
 
 		this.addDefault("Mode.Freedom.JoinText", "&6Freedom Mode &f- Right click: &2Save&f, Left click: &5Load");
 		this.addDefault("Mode.Freedom.Save", "Position saved");

--- a/src/main/java/io/github/a5h73y/parkour/conversation/other/AddKitItemConversation.java
+++ b/src/main/java/io/github/a5h73y/parkour/conversation/other/AddKitItemConversation.java
@@ -18,6 +18,7 @@ import io.github.a5h73y.parkour.utility.MaterialUtils;
 import io.github.a5h73y.parkour.utility.TranslationUtils;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -123,16 +124,26 @@ public class AddKitItemConversation {
         }
     }
 
-    private class ChoosePotionEffect extends StringPrompt {
+    private class ChoosePotionEffect extends FixedSetPrompt {
+
+        ChoosePotionEffect() {
+            super(Arrays.stream(PotionEffectType.values()).map(PotionEffectType::getName).toArray(String[]::new));
+        }
 
         @Override
         @NotNull
         public String getPromptText(@NotNull ConversationContext context) {
-            return ChatColor.LIGHT_PURPLE + " What potion effect do you want to apply to the block?";
+            return ChatColor.LIGHT_PURPLE + " What potion effect do you want to apply to " + context.getSessionData(MATERIAL) + "?\n"
+                    + ChatColor.GREEN + formatFixedSet();
         }
 
         @Override
-        public Prompt acceptInput(@NotNull ConversationContext context, String message) {
+        protected boolean isInputValid(@NotNull ConversationContext context, @NotNull String input) {
+            return super.isInputValid(context, input.toUpperCase(Locale.ROOT));
+        }
+
+        @Override
+        public Prompt acceptValidatedInput(@NotNull ConversationContext context, String message) {
             PotionEffectType effect = PotionEffectType.getByName(message.toUpperCase());
 
             if (effect == null) {

--- a/src/main/java/io/github/a5h73y/parkour/conversation/other/AddKitItemConversation.java
+++ b/src/main/java/io/github/a5h73y/parkour/conversation/other/AddKitItemConversation.java
@@ -83,7 +83,7 @@ public class AddKitItemConversation {
                 return this;
             }
 
-            if (Parkour.getDefaultConfig().contains(PARKOUR_KIT_CONFIG_PREFIX + kitName + "." + material.name())) {
+            if (Parkour.getConfig(ConfigType.PARKOURKIT).contains(PARKOUR_KIT_CONFIG_PREFIX + kitName + "." + material.name())) {
                 sendErrorMessage(context, material.name() + " already exists in this ParkourKit!");
                 return this;
             }

--- a/src/main/java/io/github/a5h73y/parkour/enums/ActionType.java
+++ b/src/main/java/io/github/a5h73y/parkour/enums/ActionType.java
@@ -12,7 +12,8 @@ public enum ActionType {
 	NORUN,
 	NOPOTION,
 	CLIMB,
-	REPULSE;
+	REPULSE,
+	POTION;
 
 	@NotNull
 	public String getDisplayName() {

--- a/src/main/java/io/github/a5h73y/parkour/listener/PlayerMoveListener.java
+++ b/src/main/java/io/github/a5h73y/parkour/listener/PlayerMoveListener.java
@@ -113,8 +113,11 @@ public class PlayerMoveListener extends AbstractPluginReceiver implements Listen
                     break;
 
                 case POTION:
-                       PlayerUtils.applyPotionEffect(PotionEffectType.getByName(kitAction.getEffect()), kitAction.getDuration(),
-                            (int) kitAction.getStrength(), player);
+                    PotionEffectType effect = PotionEffectType.getByName(kitAction.getEffect());
+                    if (effect != null) {
+                        PlayerUtils.applyPotionEffect(effect, kitAction.getDuration(),
+                                (int) kitAction.getStrength(), player);
+                    }
                     break;
 
                 case NORUN:

--- a/src/main/java/io/github/a5h73y/parkour/listener/PlayerMoveListener.java
+++ b/src/main/java/io/github/a5h73y/parkour/listener/PlayerMoveListener.java
@@ -112,6 +112,11 @@ public class PlayerMoveListener extends AbstractPluginReceiver implements Listen
                     }
                     break;
 
+                case POTION:
+                       PlayerUtils.applyPotionEffect(PotionEffectType.getByName(kitAction.getEffect()), kitAction.getDuration(),
+                            (int) kitAction.getStrength(), player);
+                    break;
+
                 case NORUN:
                     player.setSprinting(false);
                     break;

--- a/src/main/java/io/github/a5h73y/parkour/plugin/TitleUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/plugin/TitleUtils.java
@@ -58,7 +58,7 @@ public class TitleUtils extends PluginWrapper {
 	 * @param attemptTitle attempt to show the title
 	 */
 	public void sendSubTitle(Player player, String subTitle, boolean attemptTitle) {
-		sendFullTitle(player, "", subTitle, attemptTitle);
+		sendFullTitle(player, " ", subTitle, attemptTitle);
 	}
 
 	/**

--- a/src/main/java/io/github/a5h73y/parkour/type/kit/ParkourKitAction.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/kit/ParkourKitAction.java
@@ -15,6 +15,7 @@ public class ParkourKitAction implements Serializable {
 	private final ActionType actionType;
 	private final double strength;
 	private final int duration;
+	private final String effect;
 
 	/**
 	 * Construct a ParkourKitAction from the details.
@@ -23,11 +24,13 @@ public class ParkourKitAction implements Serializable {
 	 * @param actionType associated action type
 	 * @param strength action strength
 	 * @param duration action duration
+	 * @param effect action potion effect type
 	 */
-	public ParkourKitAction(ActionType actionType, double strength, int duration) {
+	public ParkourKitAction(ActionType actionType, double strength, int duration, String effect) {
 		this.actionType = actionType;
 		this.strength = strength;
 		this.duration = duration;
+		this.effect = effect;
 	}
 
 	/**
@@ -52,5 +55,13 @@ public class ParkourKitAction implements Serializable {
 	 */
 	public int getDuration() {
 		return duration;
+	}
+
+	/**
+	 * Get the Potion effect.
+	 * @return effect
+	 */
+	public String getEffect() {
+		return effect;
 	}
 }

--- a/src/main/java/io/github/a5h73y/parkour/type/kit/ParkourKitInfo.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/kit/ParkourKitInfo.java
@@ -59,6 +59,17 @@ public class ParkourKitInfo {
     }
 
     /**
+     * Get the PotionEffectType name for Material for the ParkourKit.
+     * @param kitName parkour kit name
+     * @param material material name
+     * @return matching action type name
+     */
+    public static String getEffectTypeForMaterial(String kitName, String material) {
+        return getParkourKitConfig().getString(PARKOUR_KIT_CONFIG_PREFIX + kitName.toLowerCase()
+                + "." + material.toUpperCase() + ".Effect");
+    }
+
+    /**
      * Get Parkour Courses linked to the ParkourKit.
      * @param kitName parkour kit name
      * @return List Parkour course names

--- a/src/main/java/io/github/a5h73y/parkour/type/kit/ParkourKitManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/kit/ParkourKitManager.java
@@ -176,11 +176,14 @@ public class ParkourKitManager extends AbstractPluginReceiver implements Cacheab
 			for (String material : materials) {
 				String actionTypeName = ParkourKitInfo.getActionTypeForMaterial(kitName, material);
 				ActionType actionType = validateActionType(actionTypeName);
-				if (actionType != null) {
-					TranslationUtils.sendValue(sender, material, actionTypeName);
-				} else {
+				if (actionType == null) {
 					TranslationUtils.sendMessage(sender, "Invalid Action Type: " + actionTypeName);
+					return;
 				}
+				if (actionTypeName.equalsIgnoreCase("potion")) {
+					actionTypeName += " (" + ParkourKitInfo.getEffectTypeForMaterial(kitName, material) + ")";
+				}
+				TranslationUtils.sendValue(sender, material, actionTypeName);
 			}
 
 		} else {
@@ -255,7 +258,8 @@ public class ParkourKitManager extends AbstractPluginReceiver implements Cacheab
 			if (actionType != null) {
 				double strength = config.getDouble(configPath + "Strength", 1);
 				int duration = config.getInt(configPath + "Duration", 200);
-				actionTypes.put(material, new ParkourKitAction(actionType, strength, duration));
+				String effect = config.getString(configPath + "Effect", "");
+				actionTypes.put(material, new ParkourKitAction(actionType, strength, duration, effect));
 			}
 		}
 


### PR DESCRIPTION
On servers running 1.17 or 1.17.1, subtitles are not displayed if there is no accompanying title. Previously setting title to an empty string would display the subtitle correctly.
This affects checkpoint, leave and death subtitles.

A workaround is to set the title to a space " " instead of an empty string. This has no effect on servers < 1.17.

There is an issue created for it on Spigot's Jira  - https://hub.spigotmc.org/jira/browse/SPIGOT-6608
However its low priority and there is some discussion over whether it is intended behaviour or not, so may not get fixed.
