### PR TITLE
clear cache after resetting player

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/database/ParkourDatabase.java
+++ b/src/main/java/io/github/a5h73y/parkour/database/ParkourDatabase.java
@@ -331,6 +331,7 @@ public class ParkourDatabase extends AbstractPluginReceiver implements Cacheable
         PluginUtils.debug("Deleting all Player times for " + player.getName());
         try {
             database.updateAsync("DELETE FROM time WHERE playerId='" + getPlayerId(player) + "'").get();
+            clearCache();
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
         }

--- a/src/main/java/io/github/a5h73y/parkour/plugin/BountifulApi.java
+++ b/src/main/java/io/github/a5h73y/parkour/plugin/BountifulApi.java
@@ -89,11 +89,8 @@ public class BountifulApi extends PluginWrapper {
 			}
 		}
 
-		if (ValidationUtils.isStringValid(title)) {
-			TranslationUtils.sendMessage(player, title);
-		}
-		if (ValidationUtils.isStringValid(subTitle)) {
-			TranslationUtils.sendMessage(player, subTitle);
+		if (ValidationUtils.isStringValid(title) && ValidationUtils.isStringValid(subTitle)) {
+			TranslationUtils.sendMessage(player, title + subTitle);
 		}
 	}
 

--- a/src/main/java/io/github/a5h73y/parkour/type/course/CourseManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/course/CourseManager.java
@@ -813,6 +813,7 @@ public class CourseManager extends AbstractPluginReceiver implements Cacheable<C
 
         courseConfig.save();
         parkour.getDatabase().deleteCourseTimes(courseName);
+        PlayerInfo.removeCompletedCourse(courseName);
         TranslationUtils.sendValueTranslation("Parkour.Reset", courseName, sender);
         PluginUtils.logToFile(courseName + " course was reset by " + sender.getName());
     }


### PR DESCRIPTION
Three small updates:

1) clear the cache after resetting a player's data so that placeholders update immediately

2) resetting a course should remove it from the player's list of completed courses otherwise players still receive the "course already completed" when joining the reset course the first time, even though they have no time associated with the course.

3) if finish titles are disabled in the config, the title and sub-title strings should be sent as a single message:

New:
![finishcourse1](https://user-images.githubusercontent.com/6975392/132947074-53b2e2cd-ba75-4132-b53f-786e59e79d0f.png)

Old:
![finishcourse2](https://user-images.githubusercontent.com/6975392/132947086-484dadbe-a1b5-4f76-b6c6-9de0ffa88ddc.png)
