### PR TITLE
remove possibility of empty message sent on player death

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -470,15 +470,18 @@ public class PlayerManager extends AbstractPluginReceiver {
 
 		// they haven't yet achieved a checkpoint
 		if (session.getCurrentCheckpoint() == 0 && session.getFreedomLocation() == null) {
-			String message = TranslationUtils.getCourseEventMessage(session, DEATH, "Parkour.Die1");
+			StringBuilder message = new StringBuilder(TranslationUtils.getCourseEventMessage(session, DEATH, "Parkour.Die1"));
 
 			if (parkour.getConfig().getBoolean("OnDie.ResetProgressWithNoCheckpoint")) {
 				session.resetProgress();
-				message += " " + TranslationUtils.getTranslation("Parkour.TimeReset", false);
+				if (message.length() != 0) {
+					message.append(" ");
+				}
+				message.append(TranslationUtils.getTranslation("Parkour.TimeReset", false));
 			}
 
 			if (!PlayerInfo.isQuietMode(player)) {
-				TranslationUtils.sendMessage(player, message);
+				TranslationUtils.sendMessage(player, message.toString());
 			}
 		} else {
 			if (!PlayerInfo.isQuietMode(player)) {


### PR DESCRIPTION
If the strings `Parkour.Die1` and `Parkour.TimeReset` are both set to an empty string, then in some cases a string consisting of a space is sent to the player each time they die.

This change will only add the space delimiter if `Parkour.Die1` is not an empty string.