### PR TITLE
only send parkour.continue message if player rejoins course

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/listener/PlayerListener.java
+++ b/src/main/java/io/github/a5h73y/parkour/listener/PlayerListener.java
@@ -214,13 +214,15 @@ public class PlayerListener extends AbstractPluginReceiver implements Listener {
         parkour.getScoreboardManager().addScoreboard(player, session);
         parkour.getPlayerManager().setupParkourMode(player);
 
+        if (parkour.getConfig().isPlayerLeaveCourseOnLeaveServer()) {
+            parkour.getPlayerManager().leaveCourse(player);
+            return;
+        }
+
         String currentCourse = session.getCourse().getName();
         TranslationUtils.sendValueTranslation("Parkour.Continue", currentCourse, player);
 
-        if (parkour.getConfig().isPlayerLeaveCourseOnLeaveServer()) {
-            parkour.getPlayerManager().leaveCourse(player);
-
-        } else if (parkour.getConfig().getBoolean("OnLeaveServer.TeleportToLastCheckpoint")) {
+        if (parkour.getConfig().getBoolean("OnLeaveServer.TeleportToLastCheckpoint")) {
             parkour.getPlayerManager().playerDie(player);
         }
     }


### PR DESCRIPTION
If "leave course on leave server" is true, then the player shouldn't receive the "continuing on course" message when rejoining the server.