### PR TITLE
(7.0) fix npe when adding event command

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/type/course/CourseConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/course/CourseConfig.java
@@ -906,7 +906,7 @@ public class CourseConfig extends Json {
      */
     @NotNull
     public List<String> getEventCommands(@NotNull ParkourEventType eventType) {
-        return this.get(eventType.getConfigEntry() + "Command", null);
+        return this.get(eventType.getConfigEntry() + "Command", new ArrayList<>());
     }
 
     /**


### PR DESCRIPTION
adding any event command for the first time causes an exception. Make the default command list an empty list rather than null, so the list can be added to.

