### PR TITLE
(7.0) display a consistent finish time

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/type/player/ParkourSession.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/ParkourSession.java
@@ -75,6 +75,7 @@ public class ParkourSession implements Serializable {
     public void resetTime() {
         this.timeStarted = System.currentTimeMillis();
         this.timeAccumulated = 0;
+        this.timeFinished = 0;
         this.secondsAccumulated = course.hasMaxTime() ? course.getMaxTime() : 0;
     }
 
@@ -121,7 +122,7 @@ public class ParkourSession implements Serializable {
     }
 
     public String getDisplayTime() {
-        return DateTimeUtils.displayCurrentTime(getCurrentTime());
+        return hasFinished() ? DateTimeUtils.displayCurrentTime(getTimeFinished()) : DateTimeUtils.displayCurrentTime(getCurrentTime());
     }
 
     public void recalculateTime() {
@@ -204,6 +205,10 @@ public class ParkourSession implements Serializable {
 
     public long getTimeFinished() {
         return timeFinished;
+    }
+
+    private boolean hasFinished() {
+        return timeFinished != 0;
     }
 
     public boolean isMarkedForDeletion() {


### PR DESCRIPTION
The _actual_ finish time should be displayed consistently in all messages to avoid the possibility of differing results being shown.

![multiple finish times](https://user-images.githubusercontent.com/6975392/138185510-eae1e4f6-8956-4663-89c9-bd99ce819eb3.PNG)
