### PR TITLE
(7.0) allow freedom and rocket mode tools to be changed in config

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/commands/ParkourCommands.java
+++ b/src/main/java/io/github/a5h73y/parkour/commands/ParkourCommands.java
@@ -533,6 +533,10 @@ public class ParkourCommands extends AbstractPluginReceiver implements CommandEx
 
             case "setmode":
             case "setparkourmode":
+                if (!ValidationUtils.validateArgs(player, args, 2)) {
+                    return false;
+                }
+
                 if (!PermissionUtils.hasPermissionOrCourseOwnership(player,
                         Permission.ADMIN_COURSE, getChosenCourseName(player, args, 1))) {
                     return false;

--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
@@ -425,6 +425,14 @@ public class DefaultConfig extends Yaml {
 		return getMaterialOrDefault("ParkourTool.Restart.Material", Material.AIR);
 	}
 
+	public Material getFreedomTool() {
+		return getMaterialOrDefault("ParkourTool.Freedom.Material", Material.AIR);
+	}
+
+	public Material getRocketTool() {
+		return getMaterialOrDefault("ParkourTool.Rockets.Material", Material.AIR);
+	}
+
 	public Material getAutoStartMaterial() {
 		return MaterialUtils.lookupMaterial(this.getString("AutoStart.Material"));
 	}

--- a/src/main/java/io/github/a5h73y/parkour/listener/PlayerInteractListener.java
+++ b/src/main/java/io/github/a5h73y/parkour/listener/PlayerInteractListener.java
@@ -1,7 +1,6 @@
 package io.github.a5h73y.parkour.listener;
 
 import com.cryptomorin.xseries.XBlock;
-import com.cryptomorin.xseries.XMaterial;
 import io.github.a5h73y.parkour.Parkour;
 import io.github.a5h73y.parkour.other.AbstractPluginReceiver;
 import io.github.a5h73y.parkour.type.checkpoint.Checkpoint;
@@ -150,9 +149,10 @@ public class PlayerInteractListener extends AbstractPluginReceiver implements Li
         }
 
         event.setCancelled(true);
+        Material materialInHand = MaterialUtils.getMaterialInPlayersHand(player);
 
         if (mode == ParkourMode.FREEDOM
-                && MaterialUtils.getMaterialInPlayersHand(player) == XMaterial.REDSTONE_TORCH.parseMaterial()) {
+                && materialInHand == parkour.getParkourConfig().getFreedomTool()) {
             if ((event.getAction().equals(Action.RIGHT_CLICK_BLOCK)
                     || event.getAction().equals(Action.RIGHT_CLICK_AIR))
                     && player.isOnGround()
@@ -164,13 +164,17 @@ public class PlayerInteractListener extends AbstractPluginReceiver implements Li
 
             } else if (event.getAction().equals(Action.LEFT_CLICK_BLOCK)
                     || event.getAction().equals(Action.LEFT_CLICK_AIR)) {
-                PlayerUtils.teleportToLocation(player,
-                        parkour.getPlayerManager().getParkourSession(player).getFreedomLocation());
+                Location location = parkour.getPlayerManager().getParkourSession(player).getFreedomLocation();
+                if (location == null) {
+                    TranslationUtils.sendTranslation("Error.UnknownCheckpoint", player);
+                    return;
+                }
+                PlayerUtils.teleportToLocation(player, location);
                 TranslationUtils.sendTranslation("Mode.Freedom.Load", player);
             }
 
         } else if (mode == ParkourMode.ROCKETS
-                && MaterialUtils.getMaterialInPlayersHand(player) == XMaterial.FIREWORK_ROCKET.parseMaterial()) {
+                && materialInHand == parkour.getParkourConfig().getRocketTool()) {
 
             int secondDelay = parkour.getParkourConfig().getInt("ParkourModes.Rockets.SecondCooldown");
             if (parkour.getPlayerManager().delayPlayer(player, secondDelay, "Mode.Rockets.Reloading", false)) {


### PR DESCRIPTION
This refers to issue #302 in Parkour 6.7.1 but the same exists in 7.0 and could be applied to 6.7.1.

1) respect the entries for freedom and rocket mode tools in the config, replacing the hard coded items.
2) fix exception when attempting to load (i.e. teleport to) a freedom point that hasn't yet been created.
3) fix malformed message when entering too many arguments to the 'setmode' command.

