### PR TITLE
(7.0) stop tab completer filtering out commands that take no args

### DIFF
--- a/docs/files/parkourCommands.json
+++ b/docs/files/parkourCommands.json
@@ -565,7 +565,7 @@
     "description": "By default, a Course does not have a minimum ParkourLevel requirement to join. However, if you want to enforce the progression of Parkour Courses, you can require the Player to have a ParkourLevel greater than or equal to the minimum ParkourLevel specified.",
     "permission": "Parkour.Admin.Course",
     "commandGroup": "2",
-    "autoTabSyntax": "(course) (level"
+    "autoTabSyntax": "(course) (level)"
   },
   {
     "command": "setmode",

--- a/src/main/java/io/github/a5h73y/parkour/commands/ParkourAutoTabCompleterNew.java
+++ b/src/main/java/io/github/a5h73y/parkour/commands/ParkourAutoTabCompleterNew.java
@@ -84,6 +84,9 @@ public class ParkourAutoTabCompleterNew extends AbstractPluginReceiver implement
                     if (nextArgument.startsWith(ARRAY_OPEN)) {
                         allowedCommands = Arrays.asList(selectedCommand.getAutoTabArraySelection(nextArgument));
                     } else if (nextArgument.startsWith(SUBSTITUTION_OPEN) && substitutions.containsKey(nextArgument)) {
+                        if (nextArgument.equalsIgnoreCase("(player)")) {
+                            substitutions.put("(player)", getAllOnlinePlayerNames());
+                        }
                         allowedCommands = new ArrayList<>(substitutions.get(nextArgument));
                     } else {
                         allowedCommands = Collections.singletonList(nextArgument);

--- a/src/main/java/io/github/a5h73y/parkour/commands/ParkourAutoTabCompleterNew.java
+++ b/src/main/java/io/github/a5h73y/parkour/commands/ParkourAutoTabCompleterNew.java
@@ -113,7 +113,6 @@ public class ParkourAutoTabCompleterNew extends AbstractPluginReceiver implement
         }
 
         return parkour.getCommandUsages().stream()
-                .filter(commandUsage -> commandUsage.getAutoTabSyntax() != null)
                 .filter(commandUsage -> commandUsage.getPermission() == null
                         || player.hasPermission(commandUsage.getPermission()))
                 .map(CommandUsage::getCommand)

--- a/src/main/resources/parkourCommands.json
+++ b/src/main/resources/parkourCommands.json
@@ -565,7 +565,7 @@
     "description": "By default, a Course does not have a minimum ParkourLevel requirement to join. However, if you want to enforce the progression of Parkour Courses, you can require the Player to have a ParkourLevel greater than or equal to the minimum ParkourLevel specified.",
     "permission": "Parkour.Admin.Course",
     "commandGroup": "2",
-    "autoTabSyntax": "(course) (level"
+    "autoTabSyntax": "(course) (level)"
   },
   {
     "command": "setmode",


### PR DESCRIPTION
1) Tab completer is not displaying any parkour command names that don't take any arguments, e.g. createkit, editkit, leave, reload etc. Removing the null check filter fixes this.

2) The list of online players referenced in the 'substitutions' map by "(players)" never gets updated after the initial time during onEnable when there are no players online. Therefore (player) is always substituted with nothing (an empty list). 
The list is now updated if the argument is (player).

3) fix typo in parkourCommands json