### PR TITLE
serialize player's join location

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerConfig.java
@@ -2,7 +2,6 @@ package io.github.a5h73y.parkour.type.player;
 
 import io.github.a5h73y.parkour.Parkour;
 import io.github.a5h73y.parkour.utility.TranslationUtils;
-import static io.github.a5h73y.parkour.configuration.serializable.ParkourSerializable.getMapValue;
 import java.io.File;
 import de.leonhard.storage.Json;
 import de.leonhard.storage.internal.FileType;
@@ -272,7 +271,7 @@ public class PlayerConfig extends Json {
      * @return saved join location
      */
     public Location getJoinLocation() {
-        return Location.deserialize(getMapValue((this.get("JoinLocation"))));
+        return this.getSerializable("JoinLocation", Location.class);
     }
 
     /**
@@ -288,7 +287,7 @@ public class PlayerConfig extends Json {
      * The player's current position will be saved as their join location.
      */
     public void setJoinLocation(Location location) {
-        this.set("JoinLocation", location.serialize());
+        this.setSerializable("JoinLocation", location);
     }
 
     /**

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerConfig.java
@@ -2,6 +2,7 @@ package io.github.a5h73y.parkour.type.player;
 
 import io.github.a5h73y.parkour.Parkour;
 import io.github.a5h73y.parkour.utility.TranslationUtils;
+import static io.github.a5h73y.parkour.configuration.serializable.ParkourSerializable.getMapValue;
 import java.io.File;
 import de.leonhard.storage.Json;
 import de.leonhard.storage.internal.FileType;
@@ -271,7 +272,7 @@ public class PlayerConfig extends Json {
      * @return saved join location
      */
     public Location getJoinLocation() {
-        return (Location) this.get("JoinLocation");
+        return Location.deserialize(getMapValue((this.get("JoinLocation"))));
     }
 
     /**
@@ -287,7 +288,7 @@ public class PlayerConfig extends Json {
      * The player's current position will be saved as their join location.
      */
     public void setJoinLocation(Location location) {
-        this.set("JoinLocation",location);
+        this.set("JoinLocation", location.serialize());
     }
 
     /**


### PR DESCRIPTION
Fixes class cast exception when attempting to teleport to join location
```
[13:02:55] [Server thread/WARN]: [Parkour] Task #346 for Parkour v7.0 generated an exception
java.lang.ClassCastException: class java.lang.String cannot be cast to class org.bukkit.Location (java.lang.String is in module java.base of loader 'bootstrap'; org.bukkit.Location is in unnamed module of loader java.net.URLClassLoader @46ee7fe8)
        at io.github.a5h73y.parkour.type.player.PlayerConfig.getJoinLocation(PlayerConfig.java:274) ~[?:?]
```
