### PR TITLE
Fix dependencies, 1.8 support and update maven's config options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 		<dependency>
 			<groupId>pro.husk</groupId>
 			<artifactId>mysql</artifactId>
-			<version>1.4.2</version>
+			<version>1.4.1</version>
 			<scope>compile</scope>
 			<exclusions>
 				<exclusion>
@@ -124,7 +124,7 @@
 		<dependency>
 			<groupId>de.themoep</groupId>
 			<artifactId>inventorygui</artifactId>
-			<version>1.4.2-SNAPSHOT</version>
+			<version>1.5-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<!-- XSeries -->
@@ -249,7 +249,7 @@
 					</execution>
 				</executions>
 			</plugin>
-
+			
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
@@ -277,7 +277,7 @@
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.2.0</version>
 				<configuration>
-					<outputDirectory>/Users/ashleyburns/Documents/Development/Minecraft/Server/plugins/</outputDirectory>
+					<outputDirectory>${export_dir}</outputDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<!-- MySQL database Repo -->
 		<repository>
 			<id>husk</id>
-			<url>https://maven.husk.pro/snapshots/</url>
+    		<url>https://maven.husk.pro/repository/maven-releases/</url>
 		</repository>
 		<!-- InventoryGui -->
 		<repository>
@@ -111,7 +111,7 @@
 		<dependency>
 			<groupId>pro.husk</groupId>
 			<artifactId>mysql</artifactId>
-			<version>1.4.1-SNAPSHOT</version>
+			<version>1.4.2</version>
 			<scope>compile</scope>
 			<exclusions>
 				<exclusion>

--- a/src/main/java/io/github/a5h73y/parkour/database/DatabaseManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/database/DatabaseManager.java
@@ -1,13 +1,5 @@
 package io.github.a5h73y.parkour.database;
 
-import io.github.a5h73y.parkour.Parkour;
-import io.github.a5h73y.parkour.configuration.impl.DefaultConfig;
-import io.github.a5h73y.parkour.other.ParkourConstants;
-import io.github.a5h73y.parkour.type.CacheableParkourManager;
-import io.github.a5h73y.parkour.type.Initializable;
-import io.github.a5h73y.parkour.utility.time.DateTimeUtils;
-import io.github.a5h73y.parkour.utility.PluginUtils;
-import io.github.a5h73y.parkour.utility.TranslationUtils;
 import java.io.File;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -15,13 +7,22 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
+
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import io.github.a5h73y.parkour.Parkour;
+import io.github.a5h73y.parkour.configuration.impl.DefaultConfig;
+import io.github.a5h73y.parkour.other.ParkourConstants;
+import io.github.a5h73y.parkour.type.CacheableParkourManager;
+import io.github.a5h73y.parkour.type.Initializable;
+import io.github.a5h73y.parkour.utility.PluginUtils;
+import io.github.a5h73y.parkour.utility.TranslationUtils;
+import io.github.a5h73y.parkour.utility.time.DateTimeUtils;
 import pro.husk.Database;
 import pro.husk.mysql.MySQL;
 
@@ -301,7 +302,7 @@ public class DatabaseManager extends CacheableParkourManager implements Initiali
         try {
             database.updateAsync(insertTimeUpdate).get();
             resultsCache.remove(courseName.toLowerCase());
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -343,7 +344,7 @@ public class DatabaseManager extends CacheableParkourManager implements Initiali
         try {
             database.updateAsync("DELETE FROM time WHERE playerId='" + getPlayerId(player) + "'").get();
             clearCache();
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -363,7 +364,7 @@ public class DatabaseManager extends CacheableParkourManager implements Initiali
         try {
             database.updateAsync("DELETE FROM time WHERE courseId=" + courseId).get();
             resultsCache.remove(courseName.toLowerCase());
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -385,7 +386,7 @@ public class DatabaseManager extends CacheableParkourManager implements Initiali
             database.updateAsync("DELETE FROM time WHERE playerId='" + getPlayerId(player)
                     + "' AND courseId=" + courseId).get();
             resultsCache.remove(courseName.toLowerCase());
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -402,7 +403,7 @@ public class DatabaseManager extends CacheableParkourManager implements Initiali
         try {
             database.updateAsync("DELETE FROM course WHERE name='" + courseName + "'").get();
             resultsCache.remove(courseName.toLowerCase());
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         // reset the cache

--- a/src/main/java/io/github/a5h73y/parkour/type/CacheableParkourManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/CacheableParkourManager.java
@@ -8,6 +8,7 @@ public abstract class CacheableParkourManager extends ParkourManager implements 
 		super(parkour);
 	}
 
+	@Override
 	public void teardown() {
 
 	}

--- a/src/main/java/io/github/a5h73y/parkour/type/challenge/ChallengeManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/challenge/ChallengeManager.java
@@ -4,6 +4,19 @@ import static io.github.a5h73y.parkour.other.ParkourConstants.COURSE_PLACEHOLDER
 import static io.github.a5h73y.parkour.other.ParkourConstants.DEFAULT_WALK_SPEED;
 import static io.github.a5h73y.parkour.other.ParkourConstants.PLAYER_PLACEHOLDER;
 
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.WeakHashMap;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.Nullable;
+
 import io.github.a5h73y.parkour.Parkour;
 import io.github.a5h73y.parkour.other.AbstractPluginReceiver;
 import io.github.a5h73y.parkour.other.ParkourValidation;
@@ -11,19 +24,6 @@ import io.github.a5h73y.parkour.type.player.session.ParkourSession;
 import io.github.a5h73y.parkour.utility.PlayerUtils;
 import io.github.a5h73y.parkour.utility.TranslationUtils;
 import io.github.a5h73y.parkour.utility.ValidationUtils;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.WeakHashMap;
-import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Player;
-import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Challenge Manager.


### PR DESCRIPTION
**Important**:
Instead of using dir for export directly given in `pom.xml`, I introduce the `export_dir` variable.
To use it, just add `-Dexport_dir='my\dir\to\plugins'`, or in your software options add `key: export_dir` and `value: my\dir\to\plugins`. With this, I'm able too to run this, without getting error that it don't find your own folder.

I fixed:
- MySQL pro husk project has changed their repo.
- MySQL's method require `SQLException`.
- InventoryGUI was creating error with `/pa settings <name>` because `PlayerSwapHandItemsEvent` was not found.