### PR TITLE
GitHub Actions workflow suggestions

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1,5 +1,7 @@
 name: Build
 
+env:
+  VERSION: '7.0'
 on:
   push:
     branches: [ '7.0' ]
@@ -23,10 +25,27 @@ jobs:
         cache: maven
 
     - name: Build with Maven
-      run: mvn install
+      run: mvn -B package
 
-    - uses: actions/upload-artifact@v2
-      name: Upload Artifact
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: Parkour.jar
-        path: target/Parkour-*.jar
+        tag_name: v${{ env.VERSION  }}.${{ github.run_number }}
+        release_name: Parkour-${{ env.VERSION }}.${{ github.run_number }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: target/Parkour-${{ env.VERSION }}.jar
+        asset_name: Parkour-${{ env.VERSION }}.jar
+        asset_content_type: application/java-archive
+

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -3,8 +3,8 @@ name: Build
 on:
   push:
     branches: [ '7.0' ]
-  pull_request:
-    branches: [ '7.0' ]
+      #  pull_request:
+      #    branches: [ '7.0' ]
 
 jobs:
   build:


### PR DESCRIPTION
These are a couple of suggestions to improve the dev build workflow in GitHub Actions.

1) Only create a build (jar) from a commit or merge to 7.0. Creating one every time a PR is made is probably not necessary.

2) Instead of creating an artifact (which is a zip file containing the parkour jar which has to be extracted after downloading), make use of GitHub Releases and create a release jar and upload it to the Releases tab.

In the workflow, this
```
env:
  VERSION: '7.0'
```
 and this 
```
release_name: Parkour-${{ env.VERSION }}.${{ github.run_number }}
```
will include the version number in the name of the jar file, and create a release called `Parkour-7.0.n` (where integer n increments on each release).

As an afterthought, adding "-DEV" or "-SNAPSHOT" to `VERSION` maybe better as the release is then clearly a dev build 
e.g. `Parkour-7.0-DEV.n`?