### PR TITLE
fix npe if wager amount string contains $ currency symbol

### DIFF
--- a/docs/guides/compatible-plugins.md
+++ b/docs/guides/compatible-plugins.md
@@ -168,7 +168,7 @@ An example could be walking on a pressure plate to leave the Course:
 
 [Parkour Top Ten](https://www.spigotmc.org/resources/parkour-top-ten.46268/) was created by steve4744 to allow for the Player's Head to be proudly displayed next to their best times, great for a competitive Parkour server.
 
-![Parkour Top Ten](https://i.imgur.com/c2n6QUM.png "Parkour Top Ten")
+![Parkour Top Ten](https://i.imgur.com/OGBAYkr.png "Parkour Top Ten")
 
 ## ConditionalEvents
 

--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
@@ -305,11 +305,7 @@ public class DefaultConfig extends Yaml {
 	 * @return sound name
 	 */
 	private String getSound(XSound xsound) {
-		if (xsound.isSupported()) {
-			return xsound.parseSound().name();
-		} else {
-			return "";
-		}
+		return xsound.isSupported() ? xsound.parseSound().name() : "";
 	}
 
 	private DateFormat setupDateFormat(String format, TimeZone timeZone) {

--- a/src/main/java/io/github/a5h73y/parkour/utility/TranslationUtils.java
+++ b/src/main/java/io/github/a5h73y/parkour/utility/TranslationUtils.java
@@ -13,6 +13,7 @@ import static io.github.a5h73y.parkour.utility.StringUtils.colour;
 import io.github.a5h73y.parkour.Parkour;
 import io.github.a5h73y.parkour.type.course.ParkourEventType;
 import io.github.a5h73y.parkour.type.player.session.ParkourSession;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -74,7 +75,7 @@ public class TranslationUtils {
 	                                         @Nullable String value,
 	                                         boolean prefix) {
 		return VALUE_PLACEHOLDER.matcher(getTranslation(translationKey, prefix))
-				.replaceAll(value == null ? "" : value);
+				.replaceAll(value == null ? "" : Matcher.quoteReplacement(value));
 	}
 
 	/**


### PR DESCRIPTION
If the currency name is/includes the $ symbol, when this is added to the wager string when inviting a player in a challenge it causes regex/replaceAll to interpret the $ as end of line.
```
Caused by: java.lang.IllegalArgumentException: Illegal group reference: group index is missing
        at java.util.regex.Matcher.appendExpandedReplacement(Matcher.java:1029) ~[?:?]
        at java.util.regex.Matcher.appendReplacement(Matcher.java:997) ~[?:?]
        at java.util.regex.Matcher.replaceAll(Matcher.java:1181) ~[?:?]
        at io.github.a5h73y.parkour.utility.TranslationUtils.getValueTranslation(TranslationUtils.java:77) ~[Parkour-7.0.1-release.jar:?]
```

