### PR TITLE
reset player snapshot after teleport to avoid deleting join location

### DIFF
--- a/docs/guides/compatible-plugins.md
+++ b/docs/guides/compatible-plugins.md
@@ -24,6 +24,61 @@ The `Plugin.PlaceholderAPI.CacheTime` value can be set to an interval in minutes
 
 [All the Parkour Placeholders are available here](/essential/placeholders.md).
 
+## Decent Holograms
+
+Parkour doesn't directly support [Decent Holograms](https://www.spigotmc.org/resources/decentholograms.96927/), however it can use PlaceholderAPI to create dynamic and nice looking Parkour holograms.
+
+### Example usages
+
+We can create a few examples of what is now possible. For demonstration purposes, I will be using a Course named "tutorial".
+
+<details><summary>Parkour Leaderboards (Click to expand)</summary>
+
+First we create a new Parkour leaderboard Hologram using the command and giving it a title.
+`/dh create Leaderboard_tutorial Parkour Leaderboard - Tutorial`
+
+Add a line for each position you want on the leaderboard (up to 10):
+
+`/dh line add Leaderboard_tutorial 1 %parkour_topten_tutorial_1%`
+`/dh line add Leaderboard_tutorial 1 %parkour_topten_tutorial_2%`
+`/dh line add Leaderboard_tutorial 1 %parkour_topten_tutorial_3%`
+
+Above we are using the Parkour placeholder `%parkour_topten_(course)_(position)%`.
+There is an entry in the `strings.yml` named `PlaceholderAPI.TopTenResult` which will allow you to customise the appearance and colours used.
+
+</details>
+
+<details><summary>Parkour Course Best Player (Click to expand)</summary>
+
+First we create a new Parkour leader Hologram using the command and giving it a title.
+`/dh create Leader_tutorial Parkour Leader - Tutorial`
+
+Add a line for each detail you want to display:
+
+`/dh line add Leader_tutorial 1 Best Player: %parkour_leaderboard_tutorial_1_player%`
+`/dh line add Leader_tutorial 1 Time: %parkour_leaderboard_tutorial_1_time%`
+`/dh line add Leader_tutorial 1 Deaths: %parkour_leaderboard_tutorial_1_deaths%`
+
+</details>
+
+<details><summary>Next Checkpoint (Click to expand)</summary>
+
+Display the next checkpoint for the Player to achieve, which displays a hologram above the pressure plate / action required to achieve the checkpoint.
+
+For example, when checkpoint 2 is achieved only the hologram for checkpoint 3 will be visible.
+
+![Next Checkpoint Example](https://i.imgur.com/JcnQsz6.png "Next Checkpoint Example")
+
+Stand over the place where you want the pressure plate to be and enter
+
+`/dh create (course)_checkpoint_(checkpoint) %parkour_current_checkpoint_hologram_(course)_(checkpoint)%`
+
+For example:
+
+`/dh create tutorial_checkpoint_3 %parkour_current_checkpoint_hologram_tutorial_3%`
+
+</details>
+
 ## Holographic Displays (v3.0.0+)
 
 **At the time of writing, Holographic Displays v3.0.0 is still in beta and has some known issues and could change in the future.**
@@ -84,7 +139,7 @@ For example:
 
 ## Holographic Displays (v2.x.x)
 
-Parkour doesn't directly support [Holographic Displays](https://dev.bukkit.org/projects/holographic-displays/files), however you can use PlaceholderAPI which allows you to create dynamic and nice looking Parkour holograms.
+Parkour doesn't directly support [Holographic Displays](https://dev.bukkit.org/projects/holographic-displays/files), however it can use PlaceholderAPI to create dynamic and nice looking Parkour holograms.
 
 You will need to install the following plugins to achieve this:
 * [Holographic Displays](https://dev.bukkit.org/projects/holographic-displays?gameCategorySlug=bukkit-plugins&projectID=75097)

--- a/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
+++ b/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
@@ -192,7 +192,7 @@ public class ParkourPlaceholders extends PlaceholderExpansion {
                 }
 
             case "course":
-                if (arguments.length < 3) {
+                if (arguments.length < 4) {
                     return INVALID_SYNTAX;
                 }
 

--- a/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
+++ b/src/main/java/io/github/a5h73y/parkour/ParkourPlaceholders.java
@@ -345,6 +345,10 @@ public class ParkourPlaceholders extends PlaceholderExpansion {
             case "number":
                 return String.valueOf(session.getCurrentCheckpoint());
 
+            case "next":
+                return session.getCurrentCheckpoint() < session.getCourse().getNumberOfCheckpoints()
+                        ? String.valueOf(session.getCurrentCheckpoint() + 1) : "";
+
             case "hologram":
                 if (arguments.length != 5 || !ValidationUtils.isInteger(arguments[4])) {
                     return INVALID_SYNTAX;

--- a/src/main/java/io/github/a5h73y/parkour/database/DatabaseManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/database/DatabaseManager.java
@@ -247,7 +247,7 @@ public class DatabaseManager extends CacheableParkourManager implements Initiali
 
         if (courseId > 0 && hasPlayerAchievedTime(player, courseName)) {
             String leaderboardPositionQuery = "SELECT COUNT(*) AS position FROM time WHERE courseId=? AND time < " +
-                    "(SELECT time FROM time WHERE courseId=? AND playerId=?)";
+                    "(SELECT time FROM time WHERE courseId=? AND playerId=? ORDER BY time LIMIT 1)";
 
             PluginUtils.debug("Checking leaderboard position for: " + leaderboardPositionQuery);
 

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -519,9 +519,9 @@ public class PlayerManager extends AbstractPluginReceiver implements Initializab
 				rewardPrize(player, session);
 			} else {
 				restorePlayerData(player, playerConfig);
-				playerConfig.resetPlayerDataSnapshot();
 				rewardPrize(player, session);
 				teleportCourseCompletion(player, courseName);
+				playerConfig.resetPlayerDataSnapshot();
 			}
 			parkour.getConfigManager().getCourseCompletionsConfig().addCompletedCourse(player, courseName);
 		}, parkour.getParkourConfig().getLong("OnFinish.TeleportDelay"));


### PR DESCRIPTION
1. The player data snapshot is being reset before the `teleportCourseCompletion()` method is called. If the player should be teleported to their join location, this will no longer be recorded in the snapshot data. Fixed by moving the reset to after the teleport.

2. The `%parkour_player_course_position_[course]%` placeholder only works if there is a single time recorded in the database for the player on that course. If the player has multiple times the result is fairly random. Fixed by getting the best time rather than the first time.

3. The `%parkour_current_checkpoint_next%` code was missing, so this has been added.

4. The length check for `%parkour_player_course_xxxxx%` is now fixed.

5. Updated docs with an example of how to create Parkour holograms using the `DecentHolograms` plugin.

