### PR TITLE
Add option to not reset course if player steps on AutoStart plate

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
@@ -191,6 +191,7 @@ public class DefaultConfig extends Yaml {
 		this.setDefault("DisplayTitle.Finish.Stay", 20);
 
 		this.setDefault("AutoStart.Enabled", true);
+		this.setDefault("AutoStart.ResetIfOnCousre", true);
 		this.setDefault("AutoStart.Material", "BEDROCK");
 		this.setDefault("AutoStart.TickDelay", 0);
 		this.setDefault("AutoStart.IncludeWorldName", true);

--- a/src/main/java/io/github/a5h73y/parkour/listener/interact/AutoStartListener.java
+++ b/src/main/java/io/github/a5h73y/parkour/listener/interact/AutoStartListener.java
@@ -57,7 +57,7 @@ public class AutoStartListener extends AbstractPluginReceiver implements Listene
 			ParkourSession session = parkour.getParkourSessionManager().getParkourSession(event.getPlayer());
 			if (session != null) {
 				// we only want to do something if the names match
-				if (session.getCourseName().equals(courseName)) {
+				if (session.getCourseName().equals(courseName) && parkour.getParkourConfig().getBoolean("AutoStart.ResetIfOnCourse")) {
 					session.resetProgress();
 					session.setFreedomLocation(null);
 


### PR DESCRIPTION
I've made a super long course that saves checkpoints when players quit. Issue is, sometimes players will be running around in parkour mode, and step on the autostart plate near spawn, resetting lots of progress and hard work. Adding this simple option would allow server owners to setup autostart such that it only starts a player if they are not in the course already.