### PR TITLE
fix for hideall parkour tool

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/StringsConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/StringsConfig.java
@@ -232,6 +232,7 @@ public class StringsConfig extends Yaml {
 		this.setDefault("GUI.JoinCourses.Description", "&fJoin &b%VALUE%");
 		this.setDefault("GUI.JoinCourses.Players", "Players: &b%VALUE%");
 		this.setDefault("GUI.JoinCourses.Checkpoints", "Checkpoints: &b%VALUE%");
+		this.setDefault("GUI.JoinCourses.Completed", "Completed: &b%VALUE%");
 		this.setDefault("GUI.CourseSettings.Heading", "%VALUE% Settings");
 		this.setDefault("GUI.CourseSettings.Setup.Line1", "qwertyui ");
 		this.setDefault("GUI.CourseSettings.Setup.Line2", "asdfghjkl");

--- a/src/main/java/io/github/a5h73y/parkour/gui/impl/JoinCoursesGui.java
+++ b/src/main/java/io/github/a5h73y/parkour/gui/impl/JoinCoursesGui.java
@@ -57,7 +57,9 @@ public class JoinCoursesGui implements AbstractMenu {
 											.getNumberOfPlayersOnCourse(course)), false),
 							TranslationUtils.getValueTranslation("GUI.JoinCourses.Checkpoints",
 									String.valueOf(parkour.getConfigManager().getCourseConfig(course)
-											.getCheckpointAmount()), false)
+											.getCheckpointAmount()), false),
+							TranslationUtils.getValueTranslation("GUI.JoinCourses.Completed",
+									String.valueOf(parkour.getDatabaseManager().hasPlayerAchievedTime(player, course)), false)
 					));
 		}
 		parent.addElement(group);

--- a/src/main/java/io/github/a5h73y/parkour/listener/PlayerInteractListener.java
+++ b/src/main/java/io/github/a5h73y/parkour/listener/PlayerInteractListener.java
@@ -40,16 +40,22 @@ public class PlayerInteractListener extends AbstractPluginReceiver implements Li
         DefaultConfig config = parkour.getParkourConfig();
         registerParkourTool(config.getLastCheckpointTool(), "LastCheckpoint",
                 (player, event) -> parkour.getPlayerManager().playerDie(player));
+        
         registerParkourTool(config.getHideAllDisabledTool(), "HideAll",
                 (player, event) -> handleHideAllTool(player));
-        registerParkourTool(config.getHideAllDisabledTool(), "HideAll",
+        
+        registerParkourTool(config.getHideAllEnabledTool(), "HideAll",
                 (player, event) -> handleHideAllTool(player));
+        
         registerParkourTool(config.getLeaveTool(), "Leave",
                 (player, event) -> parkour.getPlayerManager().leaveCourse(player));
+        
         registerParkourTool(config.getRestartTool(), "Restart",
                 (player, event) -> handleRestartTool(player));
+        
         registerParkourTool(config.getRocketTool(), "Rockets", true, false, ParkourMode.ROCKETS,
                 (player, event) -> handleRocketTool(player));
+        
         registerParkourTool(config.getFreedomTool(), "Freedom", false, false, ParkourMode.FREEDOM,
                 (player, event) -> handleFreedomTool(player, event.getAction()));
     }

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -1294,7 +1294,9 @@ public class PlayerManager extends AbstractPluginReceiver implements Initializab
 		}
 
 		giveParkourTool(player, "ParkourTool.LastCheckpoint");
-		giveParkourTool(player, "ParkourTool.HideAll");
+		String configPath = parkour.getParkourSessionManager().hasHiddenPlayers(player)
+				? "ParkourTool.HideAllEnabled" : "ParkourTool.HideAll";
+		giveParkourTool(player, configPath);
 		giveParkourTool(player, "ParkourTool.Leave");
 		giveParkourTool(player, "ParkourTool.Restart");
 


### PR DESCRIPTION
On a fast restart, invisible players stay invisible but the 'hideall' tool gets reset to default. This checks if hideall is enabled and sets the appropriate tool.

On a full restart, the player leaves the course and the session is deleted, so the default hideall tool is correct.
 
Added the course completion status to courses in the join menu gui.