### PR TITLE
add option to set display name on material prizes

### DIFF
--- a/docs/guides/rewarding-player.md
+++ b/docs/guides/rewarding-player.md
@@ -12,7 +12,7 @@ More information: [Click Here](/tutorials/parkour-level-ranks.md)
 
 ## Course Prize
 
-You can reward the Player several ways after they complete a Course, this can be configured by starting the Prize conversation which is initiated by entering `/pa prize (course)`.
+You can reward the Player several ways after they complete a Course. This can be configured by starting the Prize conversation which is initiated by entering `/pa setcourse (course) prize`.
 
 This will start a conversation of what you want the prize to be, these can be stacked meaning you can have all options happen when the Player finishes a Course.
 
@@ -22,7 +22,7 @@ This was made to be as simple as possible, to allow you to answer each question 
 
 ### Material
 
-The Player can be rewarded with a Material for completing the Course, and amount can be specified. The example Materials available for each server version will differ, example Material names can be [found here](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html).  
+The Player can be rewarded with a Material for completing the Course. The amount and a custom display name can be specified. The example Materials available for each server version will differ, example Material names can be [found here](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html).  
 _Once the Player completes the Course, the ItemStack will be inserted into their inventory after their original inventory is restored._
 
 ![Material Prize](https://i.imgur.com/xgLug6k.jpg "Material Prize")

--- a/docs/tutorials/parkour-config.md
+++ b/docs/tutorials/parkour-config.md
@@ -181,6 +181,7 @@ CourseDefault:
   Prize:
     Material: DIAMOND
     Amount: 1
+    Label: ''
     XP: 0
   # Should the per-course commands be combined with the default commands below
   Commands:

--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
@@ -142,6 +142,7 @@ public class DefaultConfig extends Yaml {
 
 		this.setDefault("CourseDefault.Prize.Material", "DIAMOND");
 		this.setDefault("CourseDefault.Prize.Amount", 1);
+		this.setDefault("CourseDefault.Prize.Label", "");
 		this.setDefault("CourseDefault.Prize.XP", 0);
 		this.setDefault("CourseDefault.Commands.CombinePerCourseCommands", true);
 		Arrays.stream(ParkourEventType.values()).forEach(eventType ->

--- a/src/main/java/io/github/a5h73y/parkour/conversation/CoursePrizeConversation.java
+++ b/src/main/java/io/github/a5h73y/parkour/conversation/CoursePrizeConversation.java
@@ -7,6 +7,7 @@ import io.github.a5h73y.parkour.conversation.other.ParkourConversation;
 import io.github.a5h73y.parkour.type.course.ParkourEventType;
 import io.github.a5h73y.parkour.utility.MaterialUtils;
 import io.github.a5h73y.parkour.utility.TranslationUtils;
+
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.conversations.BooleanPrompt;
@@ -111,9 +112,38 @@ public class CoursePrizeConversation extends ParkourConversation {
         @Override
         protected Prompt acceptValidatedInput(ConversationContext context, Number amount) {
             context.setSessionData(AMOUNT, amount.intValue());
-            return new MaterialProcessComplete();
+            return new ChooseDisplayName();
         }
     }
+
+    private static class ChooseDisplayName extends BooleanPrompt {
+		@Override
+		public String getPromptText(ConversationContext context) {
+			return ChatColor.LIGHT_PURPLE + " Would you like to add a custom display name?\n" +
+					ChatColor.GREEN + "[yes, no]";
+		}
+		@Override
+		protected Prompt acceptValidatedInput(ConversationContext context, boolean addName) {
+			if (addName) {
+				return new AddDisplayName();
+			}
+			context.setSessionData("label", "");
+			return new MaterialProcessComplete();
+		}
+	}
+
+	private static class AddDisplayName extends StringPrompt {
+		@Override
+		public String getPromptText(ConversationContext context) {
+			return ChatColor.LIGHT_PURPLE + " What display name do you want to attach to the " + context.getSessionData("material").toString() + "?";
+		}
+
+		@Override
+		public Prompt acceptInput(ConversationContext context, String message) {
+			context.setSessionData("label", message);
+			return new MaterialProcessComplete();
+		}
+	}
 
     private static class MaterialProcessComplete extends MessagePrompt {
 
@@ -123,7 +153,8 @@ public class CoursePrizeConversation extends ParkourConversation {
             String courseName = context.getSessionData(SESSION_COURSE_NAME).toString();
             Parkour.getInstance().getConfigManager().getCourseConfig(courseName).setMaterialPrize(
                     context.getSessionData(MATERIAL).toString(),
-                    Integer.parseInt(context.getSessionData(AMOUNT).toString()));
+                    Integer.parseInt(context.getSessionData(AMOUNT).toString()),
+                    context.getSessionData("label").toString());
 
             return TranslationUtils.getPropertySet("Material Prize", courseName,
                     context.getSessionData(AMOUNT) + " " + context.getSessionData(MATERIAL));

--- a/src/main/java/io/github/a5h73y/parkour/type/course/CourseConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/course/CourseConfig.java
@@ -66,6 +66,7 @@ public class CourseConfig extends Json {
     public static final String VIEWS = "Views";
     public static final String PRIZE_MATERIAL = "Prize.Material";
     public static final String PRIZE_AMOUNT = "Prize.Amount";
+    public static final String PRIZE_LABEL = "Prize.Label";
 
     private static final String CHECKPOINTS = "Checkpoints";
     private static final String COMMAND_PREFIX = "Command.";
@@ -423,14 +424,23 @@ public class CourseConfig extends Json {
     }
 
     /**
+     * Get display name of Material prize for Course.
+     * @return display name of material prize
+     */
+    public String getMaterialPrizeLabel() {
+        return this.getString(PRIZE_LABEL);
+    }
+
+    /**
      * Set the Material Prize for the Course.
      * The Material and Amount to be rewarded for finishing the Course.
      * @param materialName prize material
      * @param amount prize amount
      */
-    public void setMaterialPrize(@NotNull String materialName, int amount) {
+    public void setMaterialPrize(@NotNull String materialName, int amount, String label) {
         this.set(PRIZE_MATERIAL, materialName);
         this.set(PRIZE_AMOUNT, amount);
+        this.set(PRIZE_LABEL, label);
     }
 
     /**

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -675,19 +675,22 @@ public class PlayerManager extends AbstractPluginReceiver implements Initializab
 		ItemStack result = null;
 		Material material;
 		int amount;
+		String label;
 
 		if (courseConfig.hasMaterialPrize()) {
 			material = courseConfig.getMaterialPrize();
 			amount = courseConfig.getMaterialPrizeAmount();
+			label = courseConfig.getMaterialPrizeLabel();
 
 		} else {
 			material = MaterialUtils.lookupMaterial(
 					parkour.getParkourConfig().getString("CourseDefault.Prize.Material"));
 			amount = parkour.getParkourConfig().getOrDefault("CourseDefault.Prize.Amount", 0);
+			label = parkour.getParkourConfig().getString("CourseDefault.Prize.Label");
 		}
 
-		if (material != null && amount > 0) {
-			result = new ItemStack(material, amount);
+		if (material != null && material != Material.AIR && amount > 0) {
+			result = MaterialUtils.createItemStack(material, amount, label, null, null);
 		}
 		return result;
 	}


### PR DESCRIPTION
Update the prize conversation to include an option to set a custom display name for the material prize.
Update the config to allow a custom display name to be set on the default prize.