### PR TITLE
Show only one top result per player

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
@@ -278,9 +278,10 @@ public class DefaultConfig extends Yaml {
 		this.setDefault("Other.Display.PrizeCooldown", true);
 		this.setDefault("Other.Display.OnlyReadyCourses", false);
 		this.setDefault("Other.Display.CompletedCourseJoinMessage", false);
-		this.setDefault("Other.Display.IncludeDeprecatedCommands", false);
+    this.setDefault("Other.Display.IncludeDeprecatedCommands", false);
+    this.setDefault("Other.Display.OneTopResultPerPlayer", false);
 
-		this.setDefault("Other.Time.StandardFormat", "HH:mm:ss");
+    this.setDefault("Other.Time.StandardFormat", "HH:mm:ss");
 		this.setDefault("Other.Time.DetailedFormat", "HH:mm:ss:SSS");
 		this.setDefault("Other.Time.PlaceholderFormat", "HH:mm:ss:SSS");
 		this.setDefault("Other.Time.TimeZone", "GMT");

--- a/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
+++ b/src/main/java/io/github/a5h73y/parkour/configuration/impl/DefaultConfig.java
@@ -278,10 +278,10 @@ public class DefaultConfig extends Yaml {
 		this.setDefault("Other.Display.PrizeCooldown", true);
 		this.setDefault("Other.Display.OnlyReadyCourses", false);
 		this.setDefault("Other.Display.CompletedCourseJoinMessage", false);
-    this.setDefault("Other.Display.IncludeDeprecatedCommands", false);
-    this.setDefault("Other.Display.OneTopResultPerPlayer", false);
+		this.setDefault("Other.Display.IncludeDeprecatedCommands", false);
+		this.setDefault("Other.Display.OneTopResultPerPlayer", false);
 
-    this.setDefault("Other.Time.StandardFormat", "HH:mm:ss");
+		this.setDefault("Other.Time.StandardFormat", "HH:mm:ss");
 		this.setDefault("Other.Time.DetailedFormat", "HH:mm:ss:SSS");
 		this.setDefault("Other.Time.PlaceholderFormat", "HH:mm:ss:SSS");
 		this.setDefault("Other.Time.TimeZone", "GMT");

--- a/src/main/java/io/github/a5h73y/parkour/database/DatabaseManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/database/DatabaseManager.java
@@ -134,8 +134,14 @@ public class DatabaseManager extends CacheableParkourManager implements Initiali
 
         if (courseId > 0) {
             int maxEntries = calculateResultsLimit(resultsLimit);
+            String courseResultsQuery;
             PluginUtils.debug("Getting top " + maxEntries + " results for " + courseName);
-            String courseResultsQuery = SELECT_TIME_DATA_QUERY + " WHERE courseId=? ORDER BY time LIMIT ?";
+            if (parkour.getParkourConfig().getBoolean("Other.Display.OneTopResultPerPlayer")) {
+              courseResultsQuery = "SELECT courseId, playerId, MIN(time) as time, deaths FROM time WHERE courseId=? GROUP BY playerId ORDER BY time LIMIT ?";
+            }
+            else {
+              courseResultsQuery = SELECT_TIME_DATA_QUERY + " WHERE courseId=? ORDER BY time LIMIT ?";
+            }
 
             try (PreparedStatement statement = getDatabaseConnection().prepareStatement(courseResultsQuery)) {
                 statement.setInt(1, courseId);


### PR DESCRIPTION
This adds a config option to show only one result per player (default is false = original behaviour).

As far as I can tell deaths is the correct one (the one belonging to the selected time), but tbh I'm not sure if it's guaranteed that the correct one is selected. 