### PR TITLE
Added check for not started challenges

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/type/challenge/ChallengeManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/challenge/ChallengeManager.java
@@ -178,7 +178,7 @@ public class ChallengeManager extends AbstractPluginReceiver {
      */
     public boolean hasPlayerBeenChallenged(Player player) {
         return hasPlayerBeenInvited(player)
-                || challenges.values().stream().anyMatch(challenge -> challenge.isPlayerParticipating(player));
+                || challenges.values().stream().filter(challenge -> challenge.hasStarted()).anyMatch(challenge -> challenge.isPlayerParticipating(player));
     }
 
     /**
@@ -248,7 +248,7 @@ public class ChallengeManager extends AbstractPluginReceiver {
     public void completeChallenge(Player winner) {
         Challenge challenge = getChallengeForPlayer(winner);
 
-        if (challenge != null && !challenge.isForfeited(winner)) {
+        if (challenge != null && challenge.hasStarted() && !challenge.isForfeited(winner)) {
             removeChallenge(challenge.getChallengeHost());
 
             TranslationUtils.sendValueTranslation("Parkour.Challenge.Winner",
@@ -360,6 +360,9 @@ public class ChallengeManager extends AbstractPluginReceiver {
             parkour.getParkourSessionManager().forceInvisible(participant);
         }
 
+        if (parkour.getParkourSessionManager().isPlaying(participant)) {
+        	parkour.getPlayerManager().leaveCourse(participant, false);
+        }
         parkour.getPlayerManager().joinCourse(participant, challenge.getCourseName());
         participant.setWalkSpeed(0f);
         PlayerUtils.applyPotionEffect(PotionEffectType.JUMP, 100000, 100000, participant);


### PR DESCRIPTION
This is simple fix for the ability to complete challenge without any competitors by creating new challenge and then, entering the same course as provided in challenge, but without starting the challenge.
Additionally, when challenge is starting it removes all competitors from their actual course to prevent any adventages gained by not being readded to challenged course.