### PR TITLE
use centre of each block when calculating closest block

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/listener/move/ParkourBlockListener.java
+++ b/src/main/java/io/github/a5h73y/parkour/listener/move/ParkourBlockListener.java
@@ -165,7 +165,7 @@ public class ParkourBlockListener extends AbstractPluginReceiver implements List
 		BlockFace result = BLOCK_FACES.stream()
 				.filter(blockFace -> !XBlock.isAir(blockBelow.getRelative(blockFace).getType()))
 				.min(Comparator.comparing(blockFace ->
-						blockBelow.getRelative(blockFace).getLocation().distance(player.getLocation())))
+						blockBelow.getRelative(blockFace).getLocation().add(0.5, 0.5, 0.5).distance(player.getLocation())))
 				.orElse(BlockFace.NORTH);
 
 		return blockBelow.getRelative(result).getType();


### PR DESCRIPTION
When a player is over AIR but being supported by a block, calculating the closest block to a player is not always returning the correct block. 

![parkour bug](https://github.com/A5H73Y/Parkour/assets/6975392/0f16761f-d65d-44bf-966c-c59ac98c307d)

If the block location is the bottom right vertex as you look at the image, the player will be closer to the red mushroom block than the cyan wool block. In this example the player finishes the course while still being supported by the cyan wool block.

Can be recreated by making a course running north to south as in the image.

Adding 0.5 to each block location coordinate when checking the distance to the player will measure from the centre of each block and give consistent results.

