### PR TITLE
Fixed speedy ParkourMode from persisting after using /pa join

### DIFF
--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -185,6 +185,8 @@ public class PlayerManager extends AbstractPluginReceiver implements Initializab
 			session = parkour.getParkourSessionManager().addPlayer(player, new ParkourSession(course));
 		}
 
+		teardownParkourMode(player);
+
 		displayJoinMessages(player, session);
 		setupParkourMode(player);
 
@@ -1636,16 +1638,8 @@ public class PlayerManager extends AbstractPluginReceiver implements Initializab
 	}
 
 	private void teardownParkourMode(Player player) {
-		ParkourMode courseMode = parkour.getParkourSessionManager().getParkourSession(player).getParkourMode();
-
-		if (courseMode == ParkourMode.NONE) {
-			return;
-		}
-
-		if (courseMode == ParkourMode.SPEEDY) {
-			float speed = Float.parseFloat(parkour.getParkourConfig().getString("ParkourModes.Speedy.ResetSpeed"));
-			player.setWalkSpeed(speed);
-		}
+		float speed = Float.parseFloat(parkour.getParkourConfig().getString("ParkourModes.Speedy.ResetSpeed"));
+		player.setWalkSpeed(speed);
 	}
 
 	private void displayJoinMessages(Player player, ParkourSession session) {

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -1638,8 +1638,10 @@ public class PlayerManager extends AbstractPluginReceiver implements Initializab
 	}
 
 	private void teardownParkourMode(Player player) {
-		float speed = Float.parseFloat(parkour.getParkourConfig().getString("ParkourModes.Speedy.ResetSpeed"));
-		player.setWalkSpeed(speed);
+		if (player.getWalkSpeed() == Float.parseFloat(parkour.getParkourConfig().getString("ParkourModes.Speedy.SetSpeed"))) {
+			float speed = Float.parseFloat(parkour.getParkourConfig().getString("ParkourModes.Speedy.ResetSpeed"));
+			player.setWalkSpeed(speed);
+		}
 	}
 
 	private void displayJoinMessages(Player player, ParkourSession session) {

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -172,6 +172,13 @@ public class PlayerManager extends AbstractPluginReceiver implements Initializab
 		if (parkour.getParkourSessionManager().isPlaying(player)
 				&& !parkour.getParkourSessionManager().getParkourSession(player)
 				.getCourseName().equals(course.getName())) {
+			ParkourMode courseMode = parkour.getParkourSessionManager().getParkourSession(player).getParkourMode();
+
+			if (courseMode == ParkourMode.SPEEDY && course.getParkourMode() != ParkourMode.SPEEDY) {
+				float speed = Float.parseFloat(parkour.getParkourConfig().getString("ParkourModes.Speedy.ResetSpeed"));
+				player.setWalkSpeed(speed);
+			}
+
 			parkour.getParkourSessionManager().removePlayer(player);
 		}
 
@@ -184,8 +191,6 @@ public class PlayerManager extends AbstractPluginReceiver implements Initializab
 		} else {
 			session = parkour.getParkourSessionManager().addPlayer(player, new ParkourSession(course));
 		}
-
-		teardownParkourMode(player);
 
 		displayJoinMessages(player, session);
 		setupParkourMode(player);
@@ -1638,7 +1643,13 @@ public class PlayerManager extends AbstractPluginReceiver implements Initializab
 	}
 
 	private void teardownParkourMode(Player player) {
-		if (player.getWalkSpeed() != Float.parseFloat(parkour.getParkourConfig().getString("ParkourModes.Speedy.ResetSpeed"))) {
+		ParkourMode courseMode = parkour.getParkourSessionManager().getParkourSession(player).getParkourMode();
+
+		if (courseMode == ParkourMode.NONE) {
+			return;
+		}
+
+		if (courseMode == ParkourMode.SPEEDY) {
 			float speed = Float.parseFloat(parkour.getParkourConfig().getString("ParkourModes.Speedy.ResetSpeed"));
 			player.setWalkSpeed(speed);
 		}

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -1638,7 +1638,7 @@ public class PlayerManager extends AbstractPluginReceiver implements Initializab
 	}
 
 	private void teardownParkourMode(Player player) {
-		if (player.getWalkSpeed() == Float.parseFloat(parkour.getParkourConfig().getString("ParkourModes.Speedy.SetSpeed"))) {
+		if (player.getWalkSpeed() != Float.parseFloat(parkour.getParkourConfig().getString("ParkourModes.Speedy.ResetSpeed"))) {
 			float speed = Float.parseFloat(parkour.getParkourConfig().getString("ParkourModes.Speedy.ResetSpeed"));
 			player.setWalkSpeed(speed);
 		}

--- a/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
+++ b/src/main/java/io/github/a5h73y/parkour/type/player/PlayerManager.java
@@ -172,11 +172,8 @@ public class PlayerManager extends AbstractPluginReceiver implements Initializab
 		if (parkour.getParkourSessionManager().isPlaying(player)
 				&& !parkour.getParkourSessionManager().getParkourSession(player)
 				.getCourseName().equals(course.getName())) {
-			ParkourMode courseMode = parkour.getParkourSessionManager().getParkourSession(player).getParkourMode();
-
-			if (courseMode == ParkourMode.SPEEDY && course.getParkourMode() != ParkourMode.SPEEDY) {
-				float speed = Float.parseFloat(parkour.getParkourConfig().getString("ParkourModes.Speedy.ResetSpeed"));
-				player.setWalkSpeed(speed);
+			if (course.getParkourMode() != ParkourMode.SPEEDY) {
+				teardownParkourMode(player);
 			}
 
 			parkour.getParkourSessionManager().removePlayer(player);


### PR DESCRIPTION
Modified PlayerManager.joinCourse to reset player speed if they were previously on a course that had Speedy enabled and directly joined another course that did not have it enabled

This fixes an issue where after joining a course with the ParkourMode speedy, you could directly join another course that did **not** have speedy enabled, yet the increased movement speed would persist.

Steps to recreate:

- Join a course that has ParkourMode speedy enabled
- Use /pa join <course> to join another course that has a different or no ParkourMode enabled