### PR TITLE
update XSeries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
 		<dependency>
 			<groupId>com.github.cryptomorin</groupId>
 			<artifactId>XSeries</artifactId>
-			<version>13.5.1</version>
+			<version>13.7.0</version>
 		</dependency>
 		<!-- Version Compare -->
 		<dependency>


### PR DESCRIPTION
Single line commit to update XSeries which fixes the plugin being unable to start on Paper 26.1+